### PR TITLE
feat(notifications): add gRPC contract (v1)

### DIFF
--- a/proto/agynio/api/notifications/v1/notifications.proto
+++ b/proto/agynio/api/notifications/v1/notifications.proto
@@ -5,18 +5,11 @@ package agynio.api.notifications.v1;
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 
-// NotificationsService v1
-//
-// Internal notifications contract. Producers publish events; a future
-// gateway subscribes and bridges to external transports (e.g., sockets).
+// NotificationsService v1 (minimal)
+// - Publish: producers send events to rooms
+// - Subscribe: gateway receives a live stream of envelopes
 service NotificationsService {
-  // Publish a single notification to rooms.
   rpc Publish(PublishRequest) returns (PublishResponse);
-
-  // Publish a batch of notifications; each item returns success or error.
-  rpc PublishBatch(PublishBatchRequest) returns (PublishBatchResponse);
-
-  // Subscribe to envelopes filtered by rooms and/or events.
   rpc Subscribe(SubscribeRequest) returns (stream SubscribeResponse);
 }
 
@@ -24,12 +17,10 @@ service NotificationsService {
 message NotificationEnvelope {
   string id = 1; // server-generated UUID v4
   google.protobuf.Timestamp ts = 2; // server-generated acceptance time
-  string source = 3; // optional origin (e.g., "platform-server")
+  string source = 3; // origin (e.g., "platform-server")
   string event = 4; // stable event name
-  repeated string rooms = 5; // non-empty list of target rooms
+  repeated string rooms = 5; // target rooms (non-empty)
   google.protobuf.Struct payload = 6; // JSON payload (event-specific schema)
-  string trace_id = 7; // optional trace identifier
-  map<string, string> attributes = 8; // optional opaque key/value pairs
 }
 
 message PublishRequest {
@@ -37,7 +28,6 @@ message PublishRequest {
   repeated string rooms = 2;
   google.protobuf.Struct payload = 3;
   string source = 4;
-  map<string, string> attributes = 6;
 }
 
 message PublishResponse {
@@ -45,47 +35,8 @@ message PublishResponse {
   google.protobuf.Timestamp ts = 2;
 }
 
-message PublishBatchRequest {
-  repeated PublishRequest items = 1;
-}
-
-message PublishBatchResponse {
-  repeated PublishResult results = 1;
-}
-
-message PublishResult {
-  oneof result {
-    string id = 1;
-    Error error = 2;
-  }
-  google.protobuf.Timestamp ts = 3; // present on success; optional on error
-}
-
-message SubscribeRequest {
-  repeated string rooms = 1; // must be non-empty
-  repeated string events = 2; // optional filter (empty = all)
-  string cursor = 3; // optional resume token
-}
+message SubscribeRequest {}
 
 message SubscribeResponse {
   NotificationEnvelope envelope = 1;
 }
-
-message Error {
-  enum Code {
-    CODE_UNSPECIFIED = 0;
-    CODE_INVALID_ARGUMENT = 1;
-    CODE_UNAVAILABLE = 2;
-    CODE_INTERNAL = 3;
-  }
-  Code code = 1;
-  string message = 2;
-  google.protobuf.Struct details = 3;
-}
-
-// Stability notes:
-// - Event names, room names, and payload shapes remain compatible with
-//   current consumers. Payload is Struct to preserve existing JSON.
-// - Producers set event/rooms/payload; server generates id/ts.
-// - Subscribe is for internal gateway usage; filtering may evolve while
-//   maintaining wire compatibility within v1.


### PR DESCRIPTION
## Summary
This PR adds the Notifications gRPC v1 contract under `proto/agynio/api/notifications/v1/notifications.proto`.

### Minimal v1 scope
- `NotificationsService.Publish(PublishRequest) returns (PublishResponse)`
- `NotificationsService.Subscribe(SubscribeRequest) returns (stream SubscribeResponse)`
- `SubscribeRequest` is empty
- `SubscribeResponse` streams `NotificationEnvelope`

### Messages
- `NotificationEnvelope`: `id`, `ts`, `source`, `rooms`, `event`, `payload`
- `PublishRequest`: `event`, `rooms`, `payload`, `source`
- `PublishResponse`: `id`, `ts`

Add Source enum, keep event names unchanged; payload remains Struct for now.