### PR TITLE
feat(apss): add AgentStateService protobuf schema

### DIFF
--- a/proto/agynio/api/agent_state/v1/agent_state.proto
+++ b/proto/agynio/api/agent_state/v1/agent_state.proto
@@ -67,13 +67,7 @@ enum ImageDetail {
 }
 
 message ToolImageOutput {
-  oneof source {
-    string openai_file_id = 1;
-    string blob_id = 2;
-    string external_url = 3;
-    string data_url = 4;
-    bytes data = 5;
-  }
+  string external_url = 1;
   string mime_type = 10;
   ImageDetail detail = 11;
   int32 width_px = 12;


### PR DESCRIPTION
This PR adds the Agent Persistent State Service (APSS) protobuf schema:

- Package: agynio.api.apss.v1
- Service: AgentStateService
- Endpoints:
  - AppendMessages (batch append, seq assigned, CAS via version)
  - ListMessages (filters by role/kind/seq, pagination)
  - ReplaceByKind (upsert singleton kinds, archive prior)
  - TrimBySeq (trim/archive by cutoff, optional protected kinds)
  - GetConversationMetadata (version, last_seq, message_count)
- Message entity uses a single well-typed body: TextBody for now (images later via oneof extension), no external type references.
- Conversation-level optimistic concurrency with version; monotonic seq per conversation for ordering and efficient trim.

After merge, platform runtime can consume this API as the persistence layer for stateless CLI LLM loop.