### PR TITLE
Remove defaults from OpenAPI schemas

### DIFF
--- a/openapi/team/v1/components/schemas/AgentConfig.yaml
+++ b/openapi/team/v1/components/schemas/AgentConfig.yaml
@@ -1,16 +1,16 @@
 type: object
 properties:
-  model: { type: string, default: 'gpt-5' }
-  systemPrompt: { type: string, default: 'You are a helpful AI assistant.' }
-  debounceMs: { type: integer, minimum: 0, default: 0 }
-  whenBusy: { type: string, enum: ['wait', 'injectAfterTools'], default: 'wait' }
-  processBuffer: { type: string, enum: ['allTogether', 'oneByOne'], default: 'allTogether' }
-  sendFinalResponseToThread: { type: boolean, default: true }
-  summarizationKeepTokens: { type: integer, minimum: 0, default: 0 }
-  summarizationMaxTokens: { type: integer, minimum: 1, default: 512 }
-  restrictOutput: { type: boolean, default: false }
-  restrictionMessage: { type: string, default: "Do not produce a final answer directly. Before finishing, call a tool. If no tool is needed, call the 'finish' tool." }
-  restrictionMaxInjections: { type: integer, minimum: 0, default: 0 }
+  model: { type: string }
+  systemPrompt: { type: string }
+  debounceMs: { type: integer, minimum: 0 }
+  whenBusy: { type: string, enum: ['wait', 'injectAfterTools'] }
+  processBuffer: { type: string, enum: ['allTogether', 'oneByOne'] }
+  sendFinalResponseToThread: { type: boolean }
+  summarizationKeepTokens: { type: integer, minimum: 0 }
+  summarizationMaxTokens: { type: integer, minimum: 1 }
+  restrictOutput: { type: boolean }
+  restrictionMessage: { type: string }
+  restrictionMaxInjections: { type: integer, minimum: 0 }
   name: { type: string }
   role: { type: string }
 additionalProperties: false

--- a/openapi/team/v1/components/schemas/McpServerConfig.yaml
+++ b/openapi/team/v1/components/schemas/McpServerConfig.yaml
@@ -13,7 +13,7 @@ properties:
   restart:
     type: object
     properties:
-      maxAttempts: { type: integer, minimum: 1, default: 5 }
-      backoffMs: { type: integer, minimum: 1, default: 2000 }
+      maxAttempts: { type: integer, minimum: 1 }
+      backoffMs: { type: integer, minimum: 1 }
     additionalProperties: false
 additionalProperties: false

--- a/openapi/team/v1/components/schemas/MemoryBucketConfig.yaml
+++ b/openapi/team/v1/components/schemas/MemoryBucketConfig.yaml
@@ -3,6 +3,5 @@ properties:
   scope:
     type: string
     enum: [global, perThread]
-    default: global
   collectionPrefix: { type: string }
 additionalProperties: false

--- a/openapi/team/v1/components/schemas/WorkspaceConfig.yaml
+++ b/openapi/team/v1/components/schemas/WorkspaceConfig.yaml
@@ -14,8 +14,8 @@ properties:
       - { type: number }
       - { type: string }
   platform: { $ref: './WorkspacePlatform.yaml' }
-  enableDinD: { type: boolean, default: false }
-  ttlSeconds: { type: integer, minimum: 0, default: 86400 }
+  enableDinD: { type: boolean }
+  ttlSeconds: { type: integer, minimum: 0 }
   nix: { type: object }
   volumes: { $ref: './WorkspaceVolumeConfig.yaml' }
 additionalProperties: false

--- a/openapi/team/v1/components/schemas/WorkspaceVolumeConfig.yaml
+++ b/openapi/team/v1/components/schemas/WorkspaceVolumeConfig.yaml
@@ -1,5 +1,5 @@
 type: object
 properties:
-  enabled: { type: boolean, default: false }
+  enabled: { type: boolean }
   mountPath: { type: string, pattern: '^/' }
 additionalProperties: false


### PR DESCRIPTION
## Summary
- remove default values from selected OpenAPI component schemas

## Testing
- buf lint
- buf build
- npx -y @redocly/cli bundle openapi/team/v1/openapi.yaml -o dist/team-v1.yaml
- npx -y @redocly/cli bundle openapi/files/v1/openapi.yaml -o dist/files-v1.yaml
- npx -y @stoplight/spectral-cli lint dist/team-v1.yaml (warnings only, existing)
- npx -y @stoplight/spectral-cli lint dist/files-v1.yaml (warnings only, existing)

Refs #13