### PR TITLE
feat(llm): add LLM proto

### DIFF
--- a/proto/agynio/api/llm/v1/llm.proto
+++ b/proto/agynio/api/llm/v1/llm.proto
@@ -1,0 +1,182 @@
+syntax = "proto3";
+
+package agynio.api.llm.v1;
+
+import "google/protobuf/timestamp.proto";
+
+option go_package = "github.com/agynio/api/gen/agynio/api/llm/v1;llmv1";
+
+// LLMService manages provider and model resources and proxies responses.
+service LLMService {
+  // --- Providers ---
+  rpc CreateLLMProvider(CreateLLMProviderRequest) returns (CreateLLMProviderResponse);
+  rpc GetLLMProvider(GetLLMProviderRequest) returns (GetLLMProviderResponse);
+  rpc UpdateLLMProvider(UpdateLLMProviderRequest) returns (UpdateLLMProviderResponse);
+  rpc DeleteLLMProvider(DeleteLLMProviderRequest) returns (DeleteLLMProviderResponse);
+  rpc ListLLMProviders(ListLLMProvidersRequest) returns (ListLLMProvidersResponse);
+
+  // --- Models ---
+  rpc CreateModel(CreateModelRequest) returns (CreateModelResponse);
+  rpc GetModel(GetModelRequest) returns (GetModelResponse);
+  rpc UpdateModel(UpdateModelRequest) returns (UpdateModelResponse);
+  rpc DeleteModel(DeleteModelRequest) returns (DeleteModelResponse);
+  rpc ListModels(ListModelsRequest) returns (ListModelsResponse);
+
+  // --- Proxy ---
+  rpc CreateResponse(CreateResponseRequest) returns (CreateResponseResponse);
+  rpc CreateResponseStream(CreateResponseStreamRequest) returns (stream CreateResponseStreamResponse);
+}
+
+// ===========================================================================
+// Common
+// ===========================================================================
+
+message EntityMeta {
+  string id = 1; // UUID
+  google.protobuf.Timestamp created_at = 2;
+  google.protobuf.Timestamp updated_at = 3;
+}
+
+// ===========================================================================
+// Enums
+// ===========================================================================
+
+enum AuthMethod {
+  AUTH_METHOD_UNSPECIFIED = 0;
+  AUTH_METHOD_BEARER = 1;
+}
+
+// ===========================================================================
+// Provider
+// ===========================================================================
+
+message LLMProvider {
+  EntityMeta meta = 1;
+  string endpoint = 2;
+  AuthMethod auth_method = 3;
+}
+
+message CreateLLMProviderRequest {
+  string endpoint = 1;
+  AuthMethod auth_method = 2;
+  string token = 3;
+}
+
+message CreateLLMProviderResponse {
+  LLMProvider provider = 1;
+}
+
+message GetLLMProviderRequest {
+  string id = 1; // UUID
+}
+
+message GetLLMProviderResponse {
+  LLMProvider provider = 1;
+}
+
+message UpdateLLMProviderRequest {
+  string id = 1; // UUID
+  optional string endpoint = 2;
+  optional AuthMethod auth_method = 3;
+  optional string token = 4;
+}
+
+message UpdateLLMProviderResponse {
+  LLMProvider provider = 1;
+}
+
+message DeleteLLMProviderRequest {
+  string id = 1; // UUID
+}
+
+message DeleteLLMProviderResponse {}
+
+message ListLLMProvidersRequest {
+  int32 page_size = 1;
+  string page_token = 2;
+}
+
+message ListLLMProvidersResponse {
+  repeated LLMProvider providers = 1;
+  string next_page_token = 2;
+}
+
+// ===========================================================================
+// Model
+// ===========================================================================
+
+message Model {
+  EntityMeta meta = 1;
+  string name = 2;
+  string llm_provider_id = 3; // UUID
+  string remote_name = 4;
+}
+
+message CreateModelRequest {
+  string name = 1;
+  string llm_provider_id = 2; // UUID
+  string remote_name = 3;
+}
+
+message CreateModelResponse {
+  Model model = 1;
+}
+
+message GetModelRequest {
+  string id = 1; // UUID
+}
+
+message GetModelResponse {
+  Model model = 1;
+}
+
+message UpdateModelRequest {
+  string id = 1; // UUID
+  optional string name = 2;
+  optional string llm_provider_id = 3; // UUID
+  optional string remote_name = 4;
+}
+
+message UpdateModelResponse {
+  Model model = 1;
+}
+
+message DeleteModelRequest {
+  string id = 1; // UUID
+}
+
+message DeleteModelResponse {}
+
+message ListModelsRequest {
+  int32 page_size = 1;
+  string page_token = 2;
+  string llm_provider_id = 3; // optional filter by provider
+}
+
+message ListModelsResponse {
+  repeated Model models = 1;
+  string next_page_token = 2;
+}
+
+// ===========================================================================
+// Proxy
+// ===========================================================================
+
+message CreateResponseRequest {
+  string model_id = 1; // UUID
+  bytes body = 2;
+}
+
+message CreateResponseResponse {
+  bytes body = 1;
+}
+
+message CreateResponseStreamRequest {
+  string model_id = 1; // UUID
+  bytes body = 2;
+}
+
+message CreateResponseStreamResponse {
+  string event_type = 1;
+  bytes data = 2;
+}


### PR DESCRIPTION
## Summary
- add LLM service proto with provider/model CRUD and proxy RPCs
- include EntityMeta and AuthMethod enum following existing conventions

## Testing
- buf lint
- buf build
- npx -y @redocly/cli bundle openapi/team/v1/openapi.yaml -o dist/team-v1.yaml
- npx -y @redocly/cli bundle openapi/files/v1/openapi.yaml -o dist/files-v1.yaml
- npx -y @stoplight/spectral-cli lint dist/team-v1.yaml (warnings only)
- npx -y @stoplight/spectral-cli lint dist/files-v1.yaml (warnings only)

Fixes #15