### PR TITLE
feat: add ziti management proto

### DIFF
--- a/proto/agynio/api/ziti_management/v1/ziti_management.proto
+++ b/proto/agynio/api/ziti_management/v1/ziti_management.proto
@@ -1,0 +1,74 @@
+syntax = "proto3";
+
+package agynio.api.ziti_management.v1;
+
+import "google/protobuf/timestamp.proto";
+
+option go_package = "github.com/agynio/api/gen/agynio/api/ziti_management/v1;zitimanagementv1";
+
+service ZitiManagementService {
+  // Orchestrator -> create OpenZiti identity for an agent, return enrollment JWT.
+  rpc CreateAgentIdentity(CreateAgentIdentityRequest) returns (CreateAgentIdentityResponse);
+
+  // Orchestrator -> delete OpenZiti identity and its platform mapping.
+  rpc DeleteIdentity(DeleteIdentityRequest) returns (DeleteIdentityResponse);
+
+  // Orchestrator -> list all platform-managed identities (orphan reconciliation).
+  rpc ListManagedIdentities(ListManagedIdentitiesRequest) returns (ListManagedIdentitiesResponse);
+
+  // Gateway -> map OpenZiti identity ID to platform identity (hot path).
+  rpc ResolveIdentity(ResolveIdentityRequest) returns (ResolveIdentityResponse);
+}
+
+enum IdentityType {
+  IDENTITY_TYPE_UNSPECIFIED = 0;
+  IDENTITY_TYPE_AGENT = 1;
+  IDENTITY_TYPE_RUNNER = 2;
+  IDENTITY_TYPE_CHANNEL = 3;
+}
+
+message ManagedIdentity {
+  string ziti_identity_id = 1;
+  string identity_id = 2;
+  IdentityType identity_type = 3;
+  string tenant_id = 4;
+  google.protobuf.Timestamp created_at = 5;
+}
+
+message CreateAgentIdentityRequest {
+  string agent_id = 1;
+  string tenant_id = 2;
+}
+
+message CreateAgentIdentityResponse {
+  string ziti_identity_id = 1;
+  string enrollment_jwt = 2;
+}
+
+message DeleteIdentityRequest {
+  string ziti_identity_id = 1;
+}
+
+message DeleteIdentityResponse {}
+
+message ListManagedIdentitiesRequest {
+  IdentityType identity_type = 1;
+  string tenant_id = 2;
+  int32 page_size = 3;
+  string page_token = 4;
+}
+
+message ListManagedIdentitiesResponse {
+  repeated ManagedIdentity identities = 1;
+  string next_page_token = 2;
+}
+
+message ResolveIdentityRequest {
+  string ziti_identity_id = 1;
+}
+
+message ResolveIdentityResponse {
+  string identity_id = 1;
+  IdentityType identity_type = 2;
+  string tenant_id = 3;
+}


### PR DESCRIPTION
## Summary
- add ziti management proto definition for ZitiManagementService
- keep proto comments ASCII to match existing files

## Testing
- buf lint
- buf build
- $(npm config get prefix)/bin/redocly bundle openapi/team/v1/openapi.yaml -o dist/team-v1.yaml
- $(npm config get prefix)/bin/redocly bundle openapi/files/v1/openapi.yaml -o dist/files-v1.yaml
- $(npm config get prefix)/bin/redocly bundle openapi/llm/v1/openapi.yaml -o dist/llm-v1.yaml
- $(npm config get prefix)/bin/spectral lint dist/team-v1.yaml (warnings from existing specs)
- $(npm config get prefix)/bin/spectral lint dist/files-v1.yaml (warnings from existing specs)
- $(npm config get prefix)/bin/spectral lint dist/llm-v1.yaml (warnings from existing specs)

Refs #30