### PR TITLE
feat(proto): add EnrollApp RPC

### DIFF
--- a/proto/agynio/api/apps/v1/apps.proto
+++ b/proto/agynio/api/apps/v1/apps.proto
@@ -18,6 +18,10 @@ service AppsService {
   rpc GetAppProfile(GetAppProfileRequest) returns (GetAppProfileResponse);
   // Validate a service token hash and resolve its app.
   rpc ValidateServiceToken(ValidateServiceTokenRequest) returns (ValidateServiceTokenResponse);
+  // Self-enrollment: app calls at startup with its service_token.
+  // Creates (or re-creates) the OpenZiti identity + service for the app.
+  // Idempotent: cleans up old ziti resources and creates fresh ones on each call.
+  rpc EnrollApp(EnrollAppRequest) returns (EnrollAppResponse);
 }
 
 message EntityMeta {
@@ -103,4 +107,16 @@ message ValidateServiceTokenRequest {
 
 message ValidateServiceTokenResponse {
   App app = 1;
+}
+
+message EnrollAppRequest {
+  // The raw service token issued during RegisterApp.
+  string service_token = 1;
+}
+
+message EnrollAppResponse {
+  // The enrolled OpenZiti identity JSON (cert, key, CA, controller URL).
+  bytes identity_json = 1;
+  // The platform identity ID for this app.
+  string identity_id = 2;
 }

--- a/proto/agynio/api/gateway/v1/apps.proto
+++ b/proto/agynio/api/gateway/v1/apps.proto
@@ -11,4 +11,5 @@ service AppsGateway {
   rpc GetApp(agynio.api.apps.v1.GetAppRequest) returns (agynio.api.apps.v1.GetAppResponse);
   rpc ListApps(agynio.api.apps.v1.ListAppsRequest) returns (agynio.api.apps.v1.ListAppsResponse);
   rpc DeleteApp(agynio.api.apps.v1.DeleteAppRequest) returns (agynio.api.apps.v1.DeleteAppResponse);
+  rpc EnrollApp(agynio.api.apps.v1.EnrollAppRequest) returns (agynio.api.apps.v1.EnrollAppResponse);
 }


### PR DESCRIPTION
## Summary
- add EnrollApp request/response messages to apps proto
- expose EnrollApp RPC on AppsService and AppsGateway

## Testing
- buf lint
- buf build

Refs #64