### PR TITLE
feat(tracing): add summary/totals protos

### DIFF
--- a/proto/agynio/api/gateway/v1/tracing.proto
+++ b/proto/agynio/api/gateway/v1/tracing.proto
@@ -10,4 +10,6 @@ service TracingGateway {
   rpc ListSpans(agynio.api.tracing.v1.ListSpansRequest) returns (agynio.api.tracing.v1.ListSpansResponse);
   rpc GetSpan(agynio.api.tracing.v1.GetSpanRequest) returns (agynio.api.tracing.v1.GetSpanResponse);
   rpc GetTrace(agynio.api.tracing.v1.GetTraceRequest) returns (agynio.api.tracing.v1.GetTraceResponse);
+  rpc GetTraceSummary(agynio.api.tracing.v1.GetTraceSummaryRequest) returns (agynio.api.tracing.v1.GetTraceSummaryResponse);
+  rpc GetTraceSpanTotals(agynio.api.tracing.v1.GetTraceSpanTotalsRequest) returns (agynio.api.tracing.v1.GetTraceSpanTotalsResponse);
 }

--- a/proto/agynio/api/tracing/v1/tracing.proto
+++ b/proto/agynio/api/tracing/v1/tracing.proto
@@ -27,6 +27,12 @@ service TracingService {
   // Get all spans belonging to a trace, grouped by Resource and
   // InstrumentationScope.
   rpc GetTrace(GetTraceRequest) returns (GetTraceResponse);
+
+  // Get trace-level summary statistics.
+  rpc GetTraceSummary(GetTraceSummaryRequest) returns (GetTraceSummaryResponse);
+
+  // Get span totals for a trace with optional filtering.
+  rpc GetTraceSpanTotals(GetTraceSpanTotalsRequest) returns (GetTraceSpanTotalsResponse);
 }
 
 // ===========================================================================
@@ -38,6 +44,22 @@ enum ListSpansOrderBy {
   LIST_SPANS_ORDER_BY_UNSPECIFIED = 0;
   LIST_SPANS_ORDER_BY_START_TIME_DESC = 1;
   LIST_SPANS_ORDER_BY_START_TIME_ASC = 2;
+}
+
+// Derived status for a span, computed from OTel status_code + end_time.
+enum SpanStatus {
+  SPAN_STATUS_UNSPECIFIED = 0;
+  SPAN_STATUS_RUNNING = 1; // end_time = 0, status_code != ERROR
+  SPAN_STATUS_OK = 2; // end_time > 0, status_code != ERROR
+  SPAN_STATUS_ERROR = 3; // status_code = ERROR (regardless of end_time)
+}
+
+// Trace-level status derived from constituent span statuses.
+enum TraceStatus {
+  TRACE_STATUS_UNSPECIFIED = 0;
+  TRACE_STATUS_RUNNING = 1; // At least one span is RUNNING
+  TRACE_STATUS_COMPLETED = 2; // All spans ended, none with ERROR
+  TRACE_STATUS_ERROR = 3; // All spans ended, at least one ERROR
 }
 
 // ===========================================================================
@@ -53,6 +75,8 @@ message SpanFilter {
   fixed64 start_time_min = 5; // start time lower bound (inclusive, nanos)
   fixed64 start_time_max = 6; // start time upper bound (inclusive, nanos)
   optional bool in_progress = 7; // true = only in-progress, false = only completed, unset = both
+  repeated string names = 8; // multiple span names, OR-combined (takes precedence over name)
+  repeated SpanStatus statuses = 9; // derived statuses, OR-combined (takes precedence over in_progress)
 }
 
 message ListSpansRequest {
@@ -98,4 +122,46 @@ message GetTraceResponse {
   // All spans in the trace, grouped by Resource and InstrumentationScope.
   // A trace spanning multiple services will have multiple ResourceSpans entries.
   repeated opentelemetry.proto.trace.v1.ResourceSpans resource_spans = 1;
+}
+
+// ===========================================================================
+// GetTraceSummary
+// ===========================================================================
+
+message GetTraceSummaryRequest {
+  bytes trace_id = 1; // 16 bytes
+}
+
+message GetTraceSummaryResponse {
+  bytes trace_id = 1;
+  TraceStatus status = 2;
+  fixed64 first_span_start_time = 3; // earliest start_time_unix_nano
+  fixed64 last_span_start_time = 4; // latest start_time_unix_nano
+  fixed64 last_span_end_time = 5; // latest end_time_unix_nano (0 if none completed)
+  map<string, int64> counts_by_name = 6; // key = span name, value = count
+  map<string, int64> counts_by_status = 7; // key = SpanStatus enum name, value = count
+  int64 total_spans = 8;
+}
+
+// ===========================================================================
+// GetTraceSpanTotals
+// ===========================================================================
+
+message GetTraceSpanTotalsRequest {
+  bytes trace_id = 1; // 16 bytes
+  repeated string names = 2; // span names to include (empty = all)
+  repeated SpanStatus statuses = 3; // derived statuses to include (empty = all)
+}
+
+message GetTraceSpanTotalsResponse {
+  int64 span_count = 1;
+  TokenUsageTotals token_usage = 2;
+}
+
+message TokenUsageTotals {
+  int64 input_tokens = 1;
+  int64 output_tokens = 2;
+  int64 cache_read_input_tokens = 3;
+  int64 reasoning_tokens = 4;
+  int64 total_tokens = 5; // server-computed: input + output
 }


### PR DESCRIPTION
## Summary
- add span/trace status enums and summary/totals messages
- extend span filters with multi-name/status fields
- add tracing service/gateway RPCs for summary/totals

## Testing
- buf lint
- buf build
- buf breaking --against '.git#branch=main'

#73