### PR TITLE
Add EnrollRunner RPC to runners protos

### DIFF
--- a/proto/agynio/api/gateway/v1/runners.proto
+++ b/proto/agynio/api/gateway/v1/runners.proto
@@ -13,6 +13,7 @@ service RunnersGateway {
   rpc ListRunners(agynio.api.runners.v1.ListRunnersRequest) returns (agynio.api.runners.v1.ListRunnersResponse);
   rpc UpdateRunner(agynio.api.runners.v1.UpdateRunnerRequest) returns (agynio.api.runners.v1.UpdateRunnerResponse);
   rpc DeleteRunner(agynio.api.runners.v1.DeleteRunnerRequest) returns (agynio.api.runners.v1.DeleteRunnerResponse);
+  rpc EnrollRunner(agynio.api.runners.v1.EnrollRunnerRequest) returns (agynio.api.runners.v1.EnrollRunnerResponse);
 
   // --- Workloads ---
   rpc ListWorkloadsByThread(agynio.api.runners.v1.ListWorkloadsByThreadRequest) returns (agynio.api.runners.v1.ListWorkloadsByThreadResponse);

--- a/proto/agynio/api/runners/v1/runners.proto
+++ b/proto/agynio/api/runners/v1/runners.proto
@@ -15,6 +15,7 @@ service RunnersService {
   rpc UpdateRunner(UpdateRunnerRequest) returns (UpdateRunnerResponse);
   rpc DeleteRunner(DeleteRunnerRequest) returns (DeleteRunnerResponse);
   rpc ValidateServiceToken(ValidateServiceTokenRequest) returns (ValidateServiceTokenResponse);
+  rpc EnrollRunner(EnrollRunnerRequest) returns (EnrollRunnerResponse);
 
   // --- Workload state ---
   rpc CreateWorkload(CreateWorkloadRequest) returns (CreateWorkloadResponse);
@@ -107,6 +108,16 @@ message ValidateServiceTokenRequest {
 
 message ValidateServiceTokenResponse {
   Runner runner = 1;
+}
+
+message EnrollRunnerRequest {
+  string service_token = 1;
+}
+
+message EnrollRunnerResponse {
+  bytes identity_json = 1;
+  string service_name = 2;
+  string identity_id = 3;
 }
 
 // ===========================================================================


### PR DESCRIPTION
## Summary
- add EnrollRunner RPC and messages to runners v1 proto
- expose EnrollRunner on the gateway runners service

## Testing
- buf lint
- buf build

Refs #83