### PR TITLE
feat(proto): add workload filters

### DIFF
--- a/proto/agynio/api/gateway/v1/runners.proto
+++ b/proto/agynio/api/gateway/v1/runners.proto
@@ -16,6 +16,7 @@ service RunnersGateway {
   rpc EnrollRunner(agynio.api.runners.v1.EnrollRunnerRequest) returns (agynio.api.runners.v1.EnrollRunnerResponse);
 
   // --- Workloads ---
+  rpc ListWorkloads(agynio.api.runners.v1.ListWorkloadsRequest) returns (agynio.api.runners.v1.ListWorkloadsResponse);
   rpc ListWorkloadsByThread(agynio.api.runners.v1.ListWorkloadsByThreadRequest) returns (agynio.api.runners.v1.ListWorkloadsByThreadResponse);
   rpc GetWorkload(agynio.api.runners.v1.GetWorkloadRequest) returns (agynio.api.runners.v1.GetWorkloadResponse);
 }

--- a/proto/agynio/api/runners/v1/runners.proto
+++ b/proto/agynio/api/runners/v1/runners.proto
@@ -222,6 +222,8 @@ message ListWorkloadsRequest {
   int32 page_size = 1;
   string page_token = 2;
   repeated WorkloadStatus statuses = 3;
+  optional string organization_id = 4;
+  optional string runner_id = 5;
 }
 
 message ListWorkloadsResponse {


### PR DESCRIPTION
## Summary
- add organization_id and runner_id filters to ListWorkloadsRequest
- expose ListWorkloads in the RunnersGateway workload section

## Testing
- buf lint
- buf build

## Issue
- #94