### PR TITLE
feat(proto): add port exposure protos

### DIFF
--- a/proto/agynio/api/expose/v1/expose.proto
+++ b/proto/agynio/api/expose/v1/expose.proto
@@ -1,0 +1,100 @@
+syntax = "proto3";
+
+package agynio.api.expose.v1;
+
+import "google/protobuf/timestamp.proto";
+
+option go_package = "github.com/agynio/api/gen/agynio/api/expose/v1;exposev1";
+
+// ExposeService manages the lifecycle of port exposures — making ports inside
+// agent containers accessible over the OpenZiti network.
+service ExposeService {
+  // Expose a port on an agent workload. Creates OpenZiti resources and returns
+  // the exposure record (including the access URL).
+  rpc AddExposure(AddExposureRequest) returns (AddExposureResponse);
+
+  // Un-expose a port on an agent workload. Deletes the OpenZiti resources and
+  // the exposure record.
+  rpc RemoveExposure(RemoveExposureRequest) returns (RemoveExposureResponse);
+
+  // List active exposures for an agent workload.
+  rpc ListExposures(ListExposuresRequest) returns (ListExposuresResponse);
+}
+
+// ===========================================================================
+// Enums
+// ===========================================================================
+
+enum ExposureStatus {
+  EXPOSURE_STATUS_UNSPECIFIED = 0;
+  EXPOSURE_STATUS_PROVISIONING = 1;
+  EXPOSURE_STATUS_ACTIVE = 2;
+  EXPOSURE_STATUS_FAILED = 3;
+  EXPOSURE_STATUS_REMOVING = 4;
+}
+
+// ===========================================================================
+// Common
+// ===========================================================================
+
+message EntityMeta {
+  string id = 1;
+  google.protobuf.Timestamp created_at = 2;
+  google.protobuf.Timestamp updated_at = 3;
+}
+
+// ===========================================================================
+// Exposure
+// ===========================================================================
+
+message Exposure {
+  EntityMeta meta = 1;
+  string workload_id = 2;
+  string agent_id = 3;
+  int32 port = 4;
+  string openziti_service_id = 5;
+  string openziti_bind_policy_id = 6;
+  string openziti_dial_policy_id = 7;
+  string url = 8;
+  ExposureStatus status = 9;
+}
+
+// ===========================================================================
+// AddExposure
+// ===========================================================================
+
+message AddExposureRequest {
+  string workload_id = 1;
+  int32 port = 2;
+  string agent_id = 3;
+}
+
+message AddExposureResponse {
+  Exposure exposure = 1;
+}
+
+// ===========================================================================
+// RemoveExposure
+// ===========================================================================
+
+message RemoveExposureRequest {
+  string workload_id = 1;
+  int32 port = 2;
+}
+
+message RemoveExposureResponse {}
+
+// ===========================================================================
+// ListExposures
+// ===========================================================================
+
+message ListExposuresRequest {
+  string workload_id = 1;
+  int32 page_size = 2;
+  string page_token = 3;
+}
+
+message ListExposuresResponse {
+  repeated Exposure exposures = 1;
+  string next_page_token = 2;
+}

--- a/proto/agynio/api/gateway/v1/expose.proto
+++ b/proto/agynio/api/gateway/v1/expose.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package agynio.api.gateway.v1;
+
+import "agynio/api/expose/v1/expose.proto";
+
+option go_package = "github.com/agynio/api/gen/agynio/api/gateway/v1;gatewayv1";
+
+service ExposeGateway {
+  // Expose a port on an agent workload.
+  rpc AddExposure(agynio.api.expose.v1.AddExposureRequest) returns (agynio.api.expose.v1.AddExposureResponse);
+
+  // Un-expose a port on an agent workload.
+  rpc RemoveExposure(agynio.api.expose.v1.RemoveExposureRequest) returns (agynio.api.expose.v1.RemoveExposureResponse);
+
+  // List active exposures for an agent workload.
+  rpc ListExposures(agynio.api.expose.v1.ListExposuresRequest) returns (agynio.api.expose.v1.ListExposuresResponse);
+}

--- a/proto/agynio/api/gateway/v1/users.proto
+++ b/proto/agynio/api/gateway/v1/users.proto
@@ -22,4 +22,9 @@ service UsersGateway {
   rpc ListAPITokens(agynio.api.users.v1.ListAPITokensRequest) returns (agynio.api.users.v1.ListAPITokensResponse);
   rpc RevokeAPIToken(agynio.api.users.v1.RevokeAPITokenRequest) returns (agynio.api.users.v1.RevokeAPITokenResponse);
   rpc BatchGetUsers(agynio.api.users.v1.BatchGetUsersRequest) returns (agynio.api.users.v1.BatchGetUsersResponse);
+
+  // --- Devices ---
+  rpc CreateDevice(agynio.api.users.v1.CreateDeviceRequest) returns (agynio.api.users.v1.CreateDeviceResponse);
+  rpc ListDevices(agynio.api.users.v1.ListDevicesRequest) returns (agynio.api.users.v1.ListDevicesResponse);
+  rpc DeleteDevice(agynio.api.users.v1.DeleteDeviceRequest) returns (agynio.api.users.v1.DeleteDeviceResponse);
 }

--- a/proto/agynio/api/users/v1/users.proto
+++ b/proto/agynio/api/users/v1/users.proto
@@ -24,6 +24,11 @@ service UsersService {
   rpc ListUsers(ListUsersRequest) returns (ListUsersResponse);
   rpc CreateUser(CreateUserRequest) returns (CreateUserResponse);
   rpc DeleteUser(DeleteUserRequest) returns (DeleteUserResponse);
+
+  // --- Devices ---
+  rpc CreateDevice(CreateDeviceRequest) returns (CreateDeviceResponse);
+  rpc ListDevices(ListDevicesRequest) returns (ListDevicesResponse);
+  rpc DeleteDevice(DeleteDeviceRequest) returns (DeleteDeviceResponse);
 }
 
 // ===========================================================================
@@ -33,6 +38,12 @@ service UsersService {
 enum ClusterRole {
   CLUSTER_ROLE_UNSPECIFIED = 0;
   CLUSTER_ROLE_ADMIN = 1;
+}
+
+enum DeviceStatus {
+  DEVICE_STATUS_UNSPECIFIED = 0;
+  DEVICE_STATUS_PENDING = 1;
+  DEVICE_STATUS_ENROLLED = 2;
 }
 
 // ===========================================================================
@@ -52,6 +63,18 @@ message User {
   string email = 4;
   string photo_url = 5;
   string nickname = 6;
+}
+
+// ===========================================================================
+// Device
+// ===========================================================================
+
+message Device {
+  EntityMeta meta = 1;
+  string user_identity_id = 2;
+  string name = 3;
+  string openziti_identity_id = 4;
+  DeviceStatus status = 5;
 }
 
 // ===========================================================================
@@ -219,3 +242,41 @@ message ResolveAPITokenResponse {
   string identity_id = 1;
   APIToken token = 2;
 }
+
+// ===========================================================================
+// CreateDevice
+// ===========================================================================
+
+message CreateDeviceRequest {
+  string name = 1;
+}
+
+message CreateDeviceResponse {
+  Device device = 1;
+  // Enrollment JWT shown once to the user. Cannot be retrieved again.
+  string enrollment_jwt = 2;
+}
+
+// ===========================================================================
+// ListDevices
+// ===========================================================================
+
+message ListDevicesRequest {
+  int32 page_size = 1;
+  string page_token = 2;
+}
+
+message ListDevicesResponse {
+  repeated Device devices = 1;
+  string next_page_token = 2;
+}
+
+// ===========================================================================
+// DeleteDevice
+// ===========================================================================
+
+message DeleteDeviceRequest {
+  string id = 1;
+}
+
+message DeleteDeviceResponse {}

--- a/proto/agynio/api/ziti_management/v1/ziti_management.proto
+++ b/proto/agynio/api/ziti_management/v1/ziti_management.proto
@@ -47,6 +47,25 @@ service ZitiManagementService {
   // Infrastructure services -> extend the lease on a service identity.
   // Called periodically by the service to prevent GC from deleting the identity.
   rpc ExtendIdentityLease(ExtendIdentityLeaseRequest) returns (ExtendIdentityLeaseResponse);
+
+  // Expose Service -> create a single OpenZiti service policy (Bind or Dial).
+  // Returns the policy ID.
+  rpc CreateServicePolicy(CreateServicePolicyRequest) returns (CreateServicePolicyResponse);
+
+  // Expose Service -> delete an OpenZiti service policy by ID.
+  rpc DeleteServicePolicy(DeleteServicePolicyRequest) returns (DeleteServicePolicyResponse);
+
+  // Expose Service -> delete an OpenZiti service by ID.
+  // Also deletes attached config objects.
+  rpc DeleteService(DeleteServiceRequest) returns (DeleteServiceResponse);
+
+  // Users Service -> create an OpenZiti identity for a user device with
+  // roleAttributes: ["devices"] and enrollment.ott: true.
+  // Returns the identity ID and enrollment JWT.
+  rpc CreateDeviceIdentity(CreateDeviceIdentityRequest) returns (CreateDeviceIdentityResponse);
+
+  // Users Service -> delete a device's OpenZiti identity.
+  rpc DeleteDeviceIdentity(DeleteDeviceIdentityRequest) returns (DeleteDeviceIdentityResponse);
 }
 
 enum ServiceType {
@@ -56,6 +75,13 @@ enum ServiceType {
   SERVICE_TYPE_LLM_PROXY = 4;
   reserved 3;
   reserved "SERVICE_TYPE_RUNNER";
+}
+
+// The type of OpenZiti service policy.
+enum ServicePolicyType {
+  SERVICE_POLICY_TYPE_UNSPECIFIED = 0;
+  SERVICE_POLICY_TYPE_BIND = 1;
+  SERVICE_POLICY_TYPE_DIAL = 2;
 }
 
 message ManagedIdentity {
@@ -89,11 +115,37 @@ message CreateAppIdentityResponse {
   reserved "ziti_service_id";
 }
 
+// OpenZiti host.v1 config — tells the hosting sidecar where to forward traffic.
+message HostV1Config {
+  string protocol = 1;
+  string address = 2;
+  int32 port = 3;
+}
+
+// OpenZiti intercept.v1 config — tells dialing tunnelers which address to intercept.
+message InterceptV1Config {
+  repeated string protocols = 1;
+  repeated string addresses = 2;
+  repeated PortRange port_ranges = 3;
+}
+
+// A port range for intercept.v1 config.
+message PortRange {
+  int32 low = 1;
+  int32 high = 2;
+}
+
 message CreateServiceRequest {
-  // e.g. "runner-{runnerId}" or "app-{slug}"
+  // e.g. "runner-{runnerId}", "app-{slug}", or "exposed-{id}"
   string name = 1;
-  // e.g. ["runner-services"] or ["app-services"]
+  // e.g. ["runner-services"], ["app-services"], or ["exposed-services"]
   repeated string role_attributes = 2;
+  // Optional host.v1 config to create and attach to the service.
+  // Used by Expose Service for port exposure.
+  optional HostV1Config host_v1_config = 3;
+  // Optional intercept.v1 config to create and attach to the service.
+  // Used by Expose Service for port exposure.
+  optional InterceptV1Config intercept_v1_config = 4;
 }
 
 message CreateServiceResponse {
@@ -182,3 +234,74 @@ message ExtendIdentityLeaseRequest {
 }
 
 message ExtendIdentityLeaseResponse {}
+
+// ===========================================================================
+// CreateServicePolicy
+// ===========================================================================
+
+message CreateServicePolicyRequest {
+  // Policy type: Bind or Dial.
+  ServicePolicyType type = 1;
+  // Human-readable policy name (e.g. "exposed-<id>-bind").
+  string name = 2;
+  // Identity roles for the policy (e.g. ["#agent-<agentId>"] or ["#all"]).
+  repeated string identity_roles = 3;
+  // Service roles for the policy (e.g. ["@exposed-<id>"]).
+  repeated string service_roles = 4;
+}
+
+message CreateServicePolicyResponse {
+  // The OpenZiti service policy ID.
+  string ziti_service_policy_id = 1;
+}
+
+// ===========================================================================
+// DeleteServicePolicy
+// ===========================================================================
+
+message DeleteServicePolicyRequest {
+  // The OpenZiti service policy ID to delete.
+  string ziti_service_policy_id = 1;
+}
+
+message DeleteServicePolicyResponse {}
+
+// ===========================================================================
+// DeleteService
+// ===========================================================================
+
+message DeleteServiceRequest {
+  // The OpenZiti service ID to delete. Also deletes attached config objects.
+  string ziti_service_id = 1;
+}
+
+message DeleteServiceResponse {}
+
+// ===========================================================================
+// CreateDeviceIdentity
+// ===========================================================================
+
+message CreateDeviceIdentityRequest {
+  // Owning user's platform identity ID.
+  string user_identity_id = 1;
+  // User-provided device name.
+  string name = 2;
+}
+
+message CreateDeviceIdentityResponse {
+  // The OpenZiti identity ID for this device.
+  string ziti_identity_id = 1;
+  // Enrollment JWT. Shown once to the user for their Ziti tunnel client.
+  string enrollment_jwt = 2;
+}
+
+// ===========================================================================
+// DeleteDeviceIdentity
+// ===========================================================================
+
+message DeleteDeviceIdentityRequest {
+  // The OpenZiti identity ID of the device to delete.
+  string ziti_identity_id = 1;
+}
+
+message DeleteDeviceIdentityResponse {}


### PR DESCRIPTION
## Summary
- add expose service and gateway proto definitions
- extend ziti management protos for service policy/device identity support
- add device APIs to users and gateway protos

## Testing
- buf lint
- buf breaking --against '.git#ref=main'

Refs #96