### PR TITLE
feat: update workload/volume protos

### DIFF
--- a/proto/agynio/api/agents/v1/agents.proto
+++ b/proto/agynio/api/agents/v1/agents.proto
@@ -177,6 +177,7 @@ message Volume {
   string mount_path = 3;
   string size = 4;
   string description = 5;
+  optional string ttl = 6;
 }
 
 message CreateVolumeRequest {
@@ -185,6 +186,7 @@ message CreateVolumeRequest {
   string size = 3;
   string description = 4;
   string organization_id = 5;
+  optional string ttl = 6;
 }
 
 message CreateVolumeResponse {
@@ -205,6 +207,7 @@ message UpdateVolumeRequest {
   optional string mount_path = 3;
   optional string size = 4;
   optional string description = 5;
+  optional string ttl = 6;
 }
 
 message UpdateVolumeResponse {

--- a/proto/agynio/api/gateway/v1/runners.proto
+++ b/proto/agynio/api/gateway/v1/runners.proto
@@ -19,4 +19,5 @@ service RunnersGateway {
   rpc ListWorkloads(agynio.api.runners.v1.ListWorkloadsRequest) returns (agynio.api.runners.v1.ListWorkloadsResponse);
   rpc ListWorkloadsByThread(agynio.api.runners.v1.ListWorkloadsByThreadRequest) returns (agynio.api.runners.v1.ListWorkloadsByThreadResponse);
   rpc GetWorkload(agynio.api.runners.v1.GetWorkloadRequest) returns (agynio.api.runners.v1.GetWorkloadResponse);
+  rpc TouchWorkload(agynio.api.runners.v1.TouchWorkloadRequest) returns (agynio.api.runners.v1.TouchWorkloadResponse);
 }

--- a/proto/agynio/api/runner/v1/runner.proto
+++ b/proto/agynio/api/runner/v1/runner.proto
@@ -20,8 +20,12 @@ service RunnerService {
 
   rpc GetWorkloadLabels(GetWorkloadLabelsRequest) returns (GetWorkloadLabelsResponse);
 
+  rpc ListWorkloads(ListWorkloadsRequest) returns (ListWorkloadsResponse);
+
   rpc FindWorkloadsByLabels(FindWorkloadsByLabelsRequest) returns (FindWorkloadsByLabelsResponse);
   rpc ListWorkloadsByVolume(ListWorkloadsByVolumeRequest) returns (ListWorkloadsByVolumeResponse);
+
+  rpc ListVolumes(ListVolumesRequest) returns (ListVolumesResponse);
 
   rpc RemoveVolume(RemoveVolumeRequest) returns (RemoveVolumeResponse);
 
@@ -72,6 +76,9 @@ message VolumeSpec {
   // For named (persistent) volumes, the backend-level identifier.
   // Docker example: "ha_ws_<threadId>".
   string persistent_name = 3;
+
+  // Labels applied to the persistent volume claim.
+  map<string, string> labels = 4;
 
   map<string, string> additional_properties = 100;
 }
@@ -143,6 +150,9 @@ message StartWorkloadRequest {
 
   repeated ImagePullCredential image_pull_credentials = 6;
 
+  // Labels applied to the workload pod.
+  map<string, string> labels = 7;
+
   map<string, string> additional_properties = 100;
 }
 
@@ -162,6 +172,9 @@ message StartWorkloadResponse {
 
   // Present when status is FAILED.
   WorkloadFailure failure = 4;
+
+  reserved 5;
+  reserved "runner_id";
 }
 
 message WorkloadContainers {
@@ -235,6 +248,17 @@ message GetWorkloadLabelsResponse {
   map<string, string> labels = 1;
 }
 
+message ListWorkloadsRequest {}
+
+message WorkloadListItem {
+  string instance_id = 1;
+  string workload_key = 2;
+}
+
+message ListWorkloadsResponse {
+  repeated WorkloadListItem workloads = 1;
+}
+
 message FindWorkloadsByLabelsRequest {
   map<string, string> labels = 1;
   bool all = 2;
@@ -250,6 +274,17 @@ message ListWorkloadsByVolumeRequest {
 
 message ListWorkloadsByVolumeResponse {
   repeated string target_ids = 1;
+}
+
+message ListVolumesRequest {}
+
+message VolumeListItem {
+  string instance_id = 1;
+  string volume_key = 2;
+}
+
+message ListVolumesResponse {
+  repeated VolumeListItem volumes = 1;
 }
 
 message RemoveVolumeRequest {

--- a/proto/agynio/api/runners/v1/runners.proto
+++ b/proto/agynio/api/runners/v1/runners.proto
@@ -19,11 +19,20 @@ service RunnersService {
 
   // --- Workload state ---
   rpc CreateWorkload(CreateWorkloadRequest) returns (CreateWorkloadResponse);
+  rpc UpdateWorkload(UpdateWorkloadRequest) returns (UpdateWorkloadResponse);
   rpc UpdateWorkloadStatus(UpdateWorkloadStatusRequest) returns (UpdateWorkloadStatusResponse);
+  rpc TouchWorkload(TouchWorkloadRequest) returns (TouchWorkloadResponse);
   rpc DeleteWorkload(DeleteWorkloadRequest) returns (DeleteWorkloadResponse);
   rpc GetWorkload(GetWorkloadRequest) returns (GetWorkloadResponse);
   rpc ListWorkloadsByThread(ListWorkloadsByThreadRequest) returns (ListWorkloadsByThreadResponse);
   rpc ListWorkloads(ListWorkloadsRequest) returns (ListWorkloadsResponse);
+
+  // --- Volume state ---
+  rpc CreateVolume(CreateVolumeRequest) returns (CreateVolumeResponse);
+  rpc UpdateVolume(UpdateVolumeRequest) returns (UpdateVolumeResponse);
+  rpc GetVolume(GetVolumeRequest) returns (GetVolumeResponse);
+  rpc ListVolumes(ListVolumesRequest) returns (ListVolumesResponse);
+  rpc ListVolumesByThread(ListVolumesByThreadRequest) returns (ListVolumesByThreadResponse);
 }
 
 // ===========================================================================
@@ -91,6 +100,7 @@ message ListRunnersResponse {
 message UpdateRunnerRequest {
   string id = 1;
   optional string name = 2;
+  // Labels replace the existing map; omitted keys are removed.
   map<string, string> labels = 3;
 }
 
@@ -166,6 +176,10 @@ message Workload {
   WorkloadStatus status = 6;
   repeated Container containers = 7;
   string ziti_identity_id = 8;
+  optional string instance_id = 9;
+  google.protobuf.Timestamp last_activity_at = 10;
+  optional google.protobuf.Timestamp last_metering_sampled_at = 11;
+  optional google.protobuf.Timestamp removed_at = 12;
 }
 
 message CreateWorkloadRequest {
@@ -183,6 +197,19 @@ message CreateWorkloadResponse {
   Workload workload = 1;
 }
 
+message UpdateWorkloadRequest {
+  string id = 1;
+  optional WorkloadStatus status = 2;
+  repeated Container containers = 3;
+  optional string instance_id = 4;
+  optional google.protobuf.Timestamp removed_at = 5;
+  optional google.protobuf.Timestamp last_metering_sampled_at = 6;
+}
+
+message UpdateWorkloadResponse {
+  Workload workload = 1;
+}
+
 message UpdateWorkloadStatusRequest {
   string id = 1;
   WorkloadStatus status = 2;
@@ -192,6 +219,12 @@ message UpdateWorkloadStatusRequest {
 message UpdateWorkloadStatusResponse {
   Workload workload = 1;
 }
+
+message TouchWorkloadRequest {
+  string id = 1;
+}
+
+message TouchWorkloadResponse {}
 
 message DeleteWorkloadRequest {
   string id = 1;
@@ -224,9 +257,97 @@ message ListWorkloadsRequest {
   repeated WorkloadStatus statuses = 3;
   optional string organization_id = 4;
   optional string runner_id = 5;
+  optional bool pending_sample = 6;
 }
 
 message ListWorkloadsResponse {
   repeated Workload workloads = 1;
+  string next_page_token = 2;
+}
+
+// ===========================================================================
+// Volume
+// ===========================================================================
+
+enum VolumeStatus {
+  VOLUME_STATUS_UNSPECIFIED = 0;
+  VOLUME_STATUS_PROVISIONING = 1;
+  VOLUME_STATUS_ACTIVE = 2;
+  VOLUME_STATUS_DEPROVISIONING = 3;
+  VOLUME_STATUS_DELETED = 4;
+  VOLUME_STATUS_FAILED = 5;
+}
+
+message Volume {
+  EntityMeta meta = 1;
+  optional string instance_id = 2;
+  string volume_id = 3;
+  string thread_id = 4;
+  string runner_id = 5;
+  string agent_id = 6;
+  string organization_id = 7;
+  string size_gb = 8;
+  VolumeStatus status = 9;
+  optional google.protobuf.Timestamp removed_at = 10;
+  optional google.protobuf.Timestamp last_metering_sampled_at = 11;
+}
+
+message CreateVolumeRequest {
+  string id = 1;
+  string volume_id = 2;
+  string thread_id = 3;
+  string runner_id = 4;
+  string agent_id = 5;
+  string organization_id = 6;
+  string size_gb = 7;
+  VolumeStatus status = 8;
+}
+
+message CreateVolumeResponse {
+  Volume volume = 1;
+}
+
+message UpdateVolumeRequest {
+  string id = 1;
+  optional VolumeStatus status = 2;
+  optional string instance_id = 3;
+  optional google.protobuf.Timestamp removed_at = 4;
+  optional google.protobuf.Timestamp last_metering_sampled_at = 5;
+}
+
+message UpdateVolumeResponse {
+  Volume volume = 1;
+}
+
+message GetVolumeRequest {
+  string id = 1;
+}
+
+message GetVolumeResponse {
+  Volume volume = 1;
+}
+
+message ListVolumesRequest {
+  int32 page_size = 1;
+  string page_token = 2;
+  repeated VolumeStatus statuses = 3;
+  optional string organization_id = 4;
+  optional string runner_id = 5;
+  optional bool pending_sample = 6;
+}
+
+message ListVolumesResponse {
+  repeated Volume volumes = 1;
+  string next_page_token = 2;
+}
+
+message ListVolumesByThreadRequest {
+  string thread_id = 1;
+  int32 page_size = 2;
+  string page_token = 3;
+}
+
+message ListVolumesByThreadResponse {
+  repeated Volume volumes = 1;
   string next_page_token = 2;
 }


### PR DESCRIPTION
## Summary
- add workload tracking fields and volume RPCs in runners service protos
- expose TouchWorkload and runner list surfaces for workloads/volumes
- add volume TTL support in agents protos

## Testing
- buf lint
- buf build

Refs #20