### PR TITLE
feat: update protos for agent comms

### DIFF
--- a/proto/agynio/api/agents/v1/agents.proto
+++ b/proto/agynio/api/agents/v1/agents.proto
@@ -108,6 +108,7 @@ message Agent {
   ComputeResources resources = 8;
   string init_image = 9;
   string organization_id = 10;
+  string nickname = 11;
 }
 
 message CreateAgentRequest {
@@ -120,6 +121,7 @@ message CreateAgentRequest {
   ComputeResources resources = 7;
   string organization_id = 8;
   string init_image = 9;
+  string nickname = 10;
 }
 
 message CreateAgentResponse {
@@ -144,6 +146,7 @@ message UpdateAgentRequest {
   optional string image = 7;
   optional ComputeResources resources = 8;
   optional string init_image = 9;
+  optional string nickname = 10;
 }
 
 message UpdateAgentResponse {

--- a/proto/agynio/api/identity/v1/identity.proto
+++ b/proto/agynio/api/identity/v1/identity.proto
@@ -15,6 +15,13 @@ service IdentityService {
   // BatchGetIdentityTypes returns known identity types for the requested IDs.
   // Unknown identity IDs are omitted from the response.
   rpc BatchGetIdentityTypes(BatchGetIdentityTypesRequest) returns (BatchGetIdentityTypesResponse);
+  // SetNickname sets or updates the nickname for an identity within an org.
+  // Returns ALREADY_EXISTS if the nickname is already taken in the org.
+  rpc SetNickname(SetNicknameRequest) returns (SetNicknameResponse);
+  // RemoveNickname deletes the nickname entry for an identity within an org.
+  rpc RemoveNickname(RemoveNicknameRequest) returns (RemoveNicknameResponse);
+  // ResolveNickname resolves an @nickname within an org to its identity.
+  rpc ResolveNickname(ResolveNicknameRequest) returns (ResolveNicknameResponse);
 }
 
 enum IdentityType {
@@ -53,4 +60,34 @@ message IdentityTypeEntry {
 
 message BatchGetIdentityTypesResponse {
   repeated IdentityTypeEntry entries = 1;
+}
+
+message SetNicknameRequest {
+  string organization_id = 1;
+  string identity_id = 2;
+  string nickname = 3;
+  // Optional app installation ID; required for app installation nicknames.
+  optional string installation_id = 4;
+}
+
+message SetNicknameResponse {}
+
+message RemoveNicknameRequest {
+  string organization_id = 1;
+  string identity_id = 2;
+  // Optional app installation ID; required for app installation nicknames.
+  optional string installation_id = 3;
+}
+
+message RemoveNicknameResponse {}
+
+message ResolveNicknameRequest {
+  string organization_id = 1;
+  string nickname = 2;
+}
+
+message ResolveNicknameResponse {
+  string identity_id = 1;
+  IdentityType identity_type = 2;
+  optional string installation_id = 3;
 }

--- a/proto/agynio/api/threads/v1/threads.proto
+++ b/proto/agynio/api/threads/v1/threads.proto
@@ -124,8 +124,7 @@ message AddParticipantRequest {
   string thread_id = 1; // UUID
   // Deprecated: use participant instead.
   string participant_id = 2 [deprecated = true]; // UUID
-  // Deprecated: use participant instead.
-  string participant_nickname = 3 [deprecated = true];
+  reserved 3;
   // Organization scope for nickname resolution. Required with participant_nickname.
   optional string organization_id = 4; // UUID
   // Passive participants receive messages but do not trigger workload starts.

--- a/proto/agynio/api/threads/v1/threads.proto
+++ b/proto/agynio/api/threads/v1/threads.proto
@@ -65,6 +65,8 @@ message Thread {
 message Participant {
   string id = 1; // UUID
   google.protobuf.Timestamp joined_at = 2;
+  // When true, the participant receives messages but does not trigger workload starts.
+  bool passive = 3;
 }
 
 // A message within a thread.
@@ -120,6 +122,12 @@ message ArchiveThreadResponse {
 message AddParticipantRequest {
   string thread_id = 1; // UUID
   string participant_id = 2; // UUID
+  // @nickname to resolve within organization_id. Mutually exclusive with participant_id.
+  string participant_nickname = 3;
+  // Organization scope for nickname resolution. Required with participant_nickname.
+  string organization_id = 4; // UUID
+  // Passive participants receive messages but do not trigger workload starts.
+  bool passive = 5;
 }
 
 message AddParticipantResponse {
@@ -183,6 +191,8 @@ message GetUnackedMessagesRequest {
   string participant_id = 1; // UUID
   int32 page_size = 2;
   string page_token = 3;
+  // Optional thread filter.
+  optional string thread_id = 4; // UUID
 }
 
 message GetUnackedMessagesResponse {

--- a/proto/agynio/api/threads/v1/threads.proto
+++ b/proto/agynio/api/threads/v1/threads.proto
@@ -96,6 +96,7 @@ message MessageRecipient {
 
 message CreateThreadRequest {
   // Initial participant UUIDs. At least one required.
+  // Passive participants must be added with AddParticipant.
   repeated string participant_ids = 1;
 }
 
@@ -121,13 +122,23 @@ message ArchiveThreadResponse {
 
 message AddParticipantRequest {
   string thread_id = 1; // UUID
-  string participant_id = 2; // UUID
-  // @nickname to resolve within organization_id. Mutually exclusive with participant_id.
-  string participant_nickname = 3;
+  // Deprecated: use participant instead.
+  string participant_id = 2 [deprecated = true]; // UUID
+  // Deprecated: use participant instead.
+  string participant_nickname = 3 [deprecated = true];
   // Organization scope for nickname resolution. Required with participant_nickname.
-  string organization_id = 4; // UUID
+  optional string organization_id = 4; // UUID
   // Passive participants receive messages but do not trigger workload starts.
   bool passive = 5;
+  ParticipantIdentifier participant = 6;
+}
+
+message ParticipantIdentifier {
+  oneof identifier {
+    string participant_id = 1; // UUID
+    // @nickname to resolve within organization_id.
+    string participant_nickname = 2;
+  }
 }
 
 message AddParticipantResponse {


### PR DESCRIPTION
## Summary
- add identity nickname RPCs with installation_id support
- extend threads participants and requests for nicknames, passive flag, and thread filtering
- add agent nickname field to agent create/update flows

## Testing
- buf lint
- buf breaking --against '.git#branch=main'
- buf generate --template /tmp/buf.gen.yaml

## Tracking
- https://github.com/agynio/architecture/issues/132
- #132