### PR TITLE
feat(proto): add capability fields

### DIFF
--- a/proto/agynio/api/agents/v1/agents.proto
+++ b/proto/agynio/api/agents/v1/agents.proto
@@ -110,6 +110,7 @@ message Agent {
   string organization_id = 10;
   string nickname = 11;
   optional string idle_timeout = 12; // Go duration string (e.g., "30s", "5m", "1h").
+  repeated string capabilities = 13;
 }
 
 message CreateAgentRequest {
@@ -124,6 +125,7 @@ message CreateAgentRequest {
   string init_image = 9;
   string nickname = 10;
   optional string idle_timeout = 11; // Go duration string (e.g., "30s", "5m", "1h").
+  repeated string capabilities = 12;
 }
 
 message CreateAgentResponse {
@@ -150,6 +152,7 @@ message UpdateAgentRequest {
   optional string init_image = 9;
   optional string nickname = 10;
   optional string idle_timeout = 11; // Go duration string (e.g., "30s", "5m", "1h").
+  repeated string capabilities = 12;
 }
 
 message UpdateAgentResponse {

--- a/proto/agynio/api/agents/v1/agents.proto
+++ b/proto/agynio/api/agents/v1/agents.proto
@@ -110,6 +110,7 @@ message Agent {
   string organization_id = 10;
   string nickname = 11;
   optional string idle_timeout = 12; // Go duration string (e.g., "30s", "5m", "1h").
+  // Capabilities supported by this agent. Free-form strings (e.g., "privileged", "dind").
   repeated string capabilities = 13;
 }
 
@@ -125,6 +126,7 @@ message CreateAgentRequest {
   string init_image = 9;
   string nickname = 10;
   optional string idle_timeout = 11; // Go duration string (e.g., "30s", "5m", "1h").
+  // Capabilities supported by this agent. Free-form strings (e.g., "privileged", "dind").
   repeated string capabilities = 12;
 }
 
@@ -152,6 +154,7 @@ message UpdateAgentRequest {
   optional string init_image = 9;
   optional string nickname = 10;
   optional string idle_timeout = 11; // Go duration string (e.g., "30s", "5m", "1h").
+  // Capabilities replace the existing list; an empty list clears all capabilities.
   repeated string capabilities = 12;
 }
 

--- a/proto/agynio/api/runner/v1/runner.proto
+++ b/proto/agynio/api/runner/v1/runner.proto
@@ -156,6 +156,9 @@ message StartWorkloadRequest {
   // Optional workload id to use for the runner instance.
   string workload_id = 8;
 
+  // Runner-level capabilities required by the workload.
+  repeated string capabilities = 9;
+
   map<string, string> additional_properties = 100;
 }
 

--- a/proto/agynio/api/runner/v1/runner.proto
+++ b/proto/agynio/api/runner/v1/runner.proto
@@ -156,7 +156,8 @@ message StartWorkloadRequest {
   // Optional workload id to use for the runner instance.
   string workload_id = 8;
 
-  // Runner-level capabilities required by the workload.
+  // Runner-level capabilities required by the workload. Free-form strings
+  // (e.g., "privileged", "dind").
   repeated string capabilities = 9;
 
   map<string, string> additional_properties = 100;

--- a/proto/agynio/api/runners/v1/runners.proto
+++ b/proto/agynio/api/runners/v1/runners.proto
@@ -72,12 +72,14 @@ message Runner {
   map<string, string> labels = 6;
   // Per-runner OpenZiti service name (e.g. "runner-{id}")
   string openziti_service_name = 7;
+  repeated string capabilities = 8;
 }
 
 message RegisterRunnerRequest {
   string name = 1;
   optional string organization_id = 2;
   map<string, string> labels = 3;
+  repeated string capabilities = 4;
 }
 
 message RegisterRunnerResponse {
@@ -109,6 +111,7 @@ message UpdateRunnerRequest {
   optional string name = 2;
   // Labels replace the existing map; omitted keys are removed.
   map<string, string> labels = 3;
+  repeated string capabilities = 4;
 }
 
 message UpdateRunnerResponse {

--- a/proto/agynio/api/runners/v1/runners.proto
+++ b/proto/agynio/api/runners/v1/runners.proto
@@ -72,6 +72,7 @@ message Runner {
   map<string, string> labels = 6;
   // Per-runner OpenZiti service name (e.g. "runner-{id}")
   string openziti_service_name = 7;
+  // Capabilities supported by this runner. Free-form strings (e.g., "privileged", "dind").
   repeated string capabilities = 8;
 }
 
@@ -79,6 +80,7 @@ message RegisterRunnerRequest {
   string name = 1;
   optional string organization_id = 2;
   map<string, string> labels = 3;
+  // Capabilities supported by this runner. Free-form strings (e.g., "privileged", "dind").
   repeated string capabilities = 4;
 }
 
@@ -111,6 +113,7 @@ message UpdateRunnerRequest {
   optional string name = 2;
   // Labels replace the existing map; omitted keys are removed.
   map<string, string> labels = 3;
+  // Capabilities replace the existing list; an empty list clears all capabilities.
   repeated string capabilities = 4;
 }
 


### PR DESCRIPTION
## Summary
- add capabilities to agent proto messages
- add runner capability fields for runner registration and updates
- add workload-level capabilities for runner start requests

## Testing
- buf lint
- buf breaking --against '.git#branch=main'

Fixes #133