### PR TITLE
feat(threads): add participants identifiers

### DIFF
--- a/proto/agynio/api/threads/v1/threads.proto
+++ b/proto/agynio/api/threads/v1/threads.proto
@@ -104,7 +104,8 @@ message CreateThreadRequest {
   // Initial participants by UUID or nickname.
   // At least one required unless initiator metadata supplies the only participant.
   repeated ParticipantIdentifier participants = 2;
-  // Organization scope for nickname resolution. Required with participant_nickname.
+  // Organization that owns the thread; required for user callers and may be
+  // derived for agent callers when omitted.
   optional string organization_id = 3; // UUID
 }
 

--- a/proto/agynio/api/threads/v1/threads.proto
+++ b/proto/agynio/api/threads/v1/threads.proto
@@ -97,7 +97,11 @@ message MessageRecipient {
 message CreateThreadRequest {
   // Initial participant UUIDs. At least one required.
   // Passive participants must be added with AddParticipant.
-  repeated string participant_ids = 1;
+  repeated string participant_ids = 1 [deprecated = true];
+  // Initial participants by UUID or nickname.
+  repeated ParticipantIdentifier participants = 2;
+  // Organization scope for nickname resolution. Required with participant_nickname.
+  optional string organization_id = 3; // UUID
 }
 
 message CreateThreadResponse {

--- a/proto/agynio/api/threads/v1/threads.proto
+++ b/proto/agynio/api/threads/v1/threads.proto
@@ -94,11 +94,15 @@ message MessageRecipient {
 // CreateThread
 // ===========================================================================
 
+// Creates a new thread with initial participants.
+// Exactly one of participant_ids (deprecated) or participants must be provided.
+// Setting both is rejected by the server.
 message CreateThreadRequest {
-  // Initial participant UUIDs. At least one required.
-  // Passive participants must be added with AddParticipant.
+  // Deprecated: use participants instead.
+  // Initial participant UUIDs. Passive participants must be added with AddParticipant.
   repeated string participant_ids = 1 [deprecated = true];
   // Initial participants by UUID or nickname.
+  // At least one required unless initiator metadata supplies the only participant.
   repeated ParticipantIdentifier participants = 2;
   // Organization scope for nickname resolution. Required with participant_nickname.
   optional string organization_id = 3; // UUID

--- a/proto/agynio/api/threads/v1/threads.proto
+++ b/proto/agynio/api/threads/v1/threads.proto
@@ -104,8 +104,8 @@ message CreateThreadRequest {
   // Initial participants by UUID or nickname.
   // At least one required unless initiator metadata supplies the only participant.
   repeated ParticipantIdentifier participants = 2;
-  // Organization that owns the thread; required for user callers and may be
-  // derived for agent callers when omitted.
+  // Organization context for thread creation; may be derived from the caller
+  // identity when omitted and used as the nickname resolution scope.
   optional string organization_id = 3; // UUID
 }
 
@@ -134,7 +134,8 @@ message AddParticipantRequest {
   // Deprecated: use participant instead.
   string participant_id = 2 [deprecated = true]; // UUID
   reserved 3;
-  // Organization scope for nickname resolution. Required with participant_nickname.
+  // Organization context for the thread; may be derived from the caller
+  // identity when omitted and used as the nickname resolution scope.
   optional string organization_id = 4; // UUID
   // Passive participants receive messages but do not trigger workload starts.
   bool passive = 5;


### PR DESCRIPTION
## Summary
- deprecate CreateThread participant_ids in favor of ParticipantIdentifier list
- add participants and organization_id fields for nickname resolution

## Testing
- buf lint

Fixes #118