### PR TITLE
feat: add org thread RPCs

### DIFF
--- a/proto/agynio/api/gateway/v1/apps.proto
+++ b/proto/agynio/api/gateway/v1/apps.proto
@@ -10,6 +10,7 @@ service AppsGateway {
   rpc CreateApp(agynio.api.apps.v1.CreateAppRequest) returns (agynio.api.apps.v1.CreateAppResponse);
   rpc UpdateApp(agynio.api.apps.v1.UpdateAppRequest) returns (agynio.api.apps.v1.UpdateAppResponse);
   rpc GetApp(agynio.api.apps.v1.GetAppRequest) returns (agynio.api.apps.v1.GetAppResponse);
+  rpc GetAppProfile(agynio.api.apps.v1.GetAppProfileRequest) returns (agynio.api.apps.v1.GetAppProfileResponse);
   rpc GetAppBySlug(agynio.api.apps.v1.GetAppBySlugRequest) returns (agynio.api.apps.v1.GetAppBySlugResponse);
   rpc ListApps(agynio.api.apps.v1.ListAppsRequest) returns (agynio.api.apps.v1.ListAppsResponse);
   rpc DeleteApp(agynio.api.apps.v1.DeleteAppRequest) returns (agynio.api.apps.v1.DeleteAppResponse);

--- a/proto/agynio/api/gateway/v1/threads.proto
+++ b/proto/agynio/api/gateway/v1/threads.proto
@@ -12,6 +12,8 @@ service ThreadsGateway {
   rpc AddParticipant(agynio.api.threads.v1.AddParticipantRequest) returns (agynio.api.threads.v1.AddParticipantResponse);
   rpc SendMessage(agynio.api.threads.v1.SendMessageRequest) returns (agynio.api.threads.v1.SendMessageResponse);
   rpc GetThreads(agynio.api.threads.v1.GetThreadsRequest) returns (agynio.api.threads.v1.GetThreadsResponse);
+  rpc ListOrganizationThreads(agynio.api.threads.v1.ListOrganizationThreadsRequest) returns (agynio.api.threads.v1.ListOrganizationThreadsResponse);
+  rpc GetThread(agynio.api.threads.v1.GetThreadRequest) returns (agynio.api.threads.v1.GetThreadResponse);
   rpc GetMessages(agynio.api.threads.v1.GetMessagesRequest) returns (agynio.api.threads.v1.GetMessagesResponse);
   rpc GetUnackedMessages(agynio.api.threads.v1.GetUnackedMessagesRequest) returns (agynio.api.threads.v1.GetUnackedMessagesResponse);
   rpc AckMessages(agynio.api.threads.v1.AckMessagesRequest) returns (agynio.api.threads.v1.AckMessagesResponse);

--- a/proto/agynio/api/gateway/v1/threads.proto
+++ b/proto/agynio/api/gateway/v1/threads.proto
@@ -12,7 +12,7 @@ service ThreadsGateway {
   rpc AddParticipant(agynio.api.threads.v1.AddParticipantRequest) returns (agynio.api.threads.v1.AddParticipantResponse);
   rpc SendMessage(agynio.api.threads.v1.SendMessageRequest) returns (agynio.api.threads.v1.SendMessageResponse);
   rpc GetThreads(agynio.api.threads.v1.GetThreadsRequest) returns (agynio.api.threads.v1.GetThreadsResponse);
-  rpc ListOrganizationThreads(agynio.api.threads.v1.ListOrganizationThreadsRequest) returns (agynio.api.threads.v1.ListOrganizationThreadsResponse);
+  rpc GetOrganizationThreads(agynio.api.threads.v1.GetOrganizationThreadsRequest) returns (agynio.api.threads.v1.GetOrganizationThreadsResponse);
   rpc GetThread(agynio.api.threads.v1.GetThreadRequest) returns (agynio.api.threads.v1.GetThreadResponse);
   rpc GetMessages(agynio.api.threads.v1.GetMessagesRequest) returns (agynio.api.threads.v1.GetMessagesResponse);
   rpc GetUnackedMessages(agynio.api.threads.v1.GetUnackedMessagesRequest) returns (agynio.api.threads.v1.GetUnackedMessagesResponse);

--- a/proto/agynio/api/threads/v1/threads.proto
+++ b/proto/agynio/api/threads/v1/threads.proto
@@ -27,8 +27,8 @@ service ThreadsService {
   // List threads for a participant with pagination.
   rpc GetThreads(GetThreadsRequest) returns (GetThreadsResponse);
 
-  // List threads for an organization with pagination.
-  rpc ListOrganizationThreads(ListOrganizationThreadsRequest) returns (ListOrganizationThreadsResponse);
+  // Get threads for an organization with pagination.
+  rpc GetOrganizationThreads(GetOrganizationThreadsRequest) returns (GetOrganizationThreadsResponse);
 
   // Get a thread by ID.
   rpc GetThread(GetThreadRequest) returns (GetThreadResponse);
@@ -71,7 +71,10 @@ message Thread {
   ThreadStatus status = 3;
   google.protobuf.Timestamp created_at = 4;
   google.protobuf.Timestamp updated_at = 5;
-  string organization_id = 6; // UUID
+  // Owning organization UUID. May be empty for legacy threads created
+  // before organization linkage was recorded.
+  string organization_id = 6;
+  // Count of messages in the thread, updated on send.
   int32 message_count = 7;
 }
 
@@ -203,17 +206,18 @@ message GetThreadsResponse {
 }
 
 // ===========================================================================
-// ListOrganizationThreads
+// GetOrganizationThreads
 // ===========================================================================
 
-message ListOrganizationThreadsRequest {
+message GetOrganizationThreadsRequest {
   string organization_id = 1; // UUID
   int32 page_size = 2;
   string page_token = 3;
-  optional ThreadStatus status = 4;
+  // Filter by status. THREAD_STATUS_UNSPECIFIED means no filter.
+  ThreadStatus status = 4;
 }
 
-message ListOrganizationThreadsResponse {
+message GetOrganizationThreadsResponse {
   repeated Thread threads = 1;
   string next_page_token = 2;
 }
@@ -238,6 +242,8 @@ message GetMessagesRequest {
   string thread_id = 1; // UUID
   int32 page_size = 2;
   string page_token = 3;
+  // Message ordering for pagination. Defaults to MESSAGE_ORDER_OLDEST_FIRST.
+  // page_token values are order-sensitive; reuse only with the same order.
   MessageOrder order = 4;
 }
 

--- a/proto/agynio/api/threads/v1/threads.proto
+++ b/proto/agynio/api/threads/v1/threads.proto
@@ -27,6 +27,12 @@ service ThreadsService {
   // List threads for a participant with pagination.
   rpc GetThreads(GetThreadsRequest) returns (GetThreadsResponse);
 
+  // List threads for an organization with pagination.
+  rpc ListOrganizationThreads(ListOrganizationThreadsRequest) returns (ListOrganizationThreadsResponse);
+
+  // Get a thread by ID.
+  rpc GetThread(GetThreadRequest) returns (GetThreadResponse);
+
   // List messages in a thread with pagination.
   // Read-only — does not change acknowledgment state.
   rpc GetMessages(GetMessagesRequest) returns (GetMessagesResponse);
@@ -48,6 +54,12 @@ enum ThreadStatus {
   THREAD_STATUS_ARCHIVED = 2;
 }
 
+enum MessageOrder {
+  MESSAGE_ORDER_UNSPECIFIED = 0;
+  MESSAGE_ORDER_OLDEST_FIRST = 1;
+  MESSAGE_ORDER_NEWEST_FIRST = 2;
+}
+
 // ===========================================================================
 // Entities
 // ===========================================================================
@@ -59,6 +71,8 @@ message Thread {
   ThreadStatus status = 3;
   google.protobuf.Timestamp created_at = 4;
   google.protobuf.Timestamp updated_at = 5;
+  string organization_id = 6; // UUID
+  int32 message_count = 7;
 }
 
 // A participant in a thread.
@@ -189,6 +203,34 @@ message GetThreadsResponse {
 }
 
 // ===========================================================================
+// ListOrganizationThreads
+// ===========================================================================
+
+message ListOrganizationThreadsRequest {
+  string organization_id = 1; // UUID
+  int32 page_size = 2;
+  string page_token = 3;
+  optional ThreadStatus status = 4;
+}
+
+message ListOrganizationThreadsResponse {
+  repeated Thread threads = 1;
+  string next_page_token = 2;
+}
+
+// ===========================================================================
+// GetThread
+// ===========================================================================
+
+message GetThreadRequest {
+  string thread_id = 1; // UUID
+}
+
+message GetThreadResponse {
+  Thread thread = 1;
+}
+
+// ===========================================================================
 // GetMessages
 // ===========================================================================
 
@@ -196,6 +238,7 @@ message GetMessagesRequest {
   string thread_id = 1; // UUID
   int32 page_size = 2;
   string page_token = 3;
+  MessageOrder order = 4;
 }
 
 message GetMessagesResponse {


### PR DESCRIPTION
## Summary
- Add organization-scoped threads RPCs + thread fields
- Add message order enum and parameter to GetMessages
- Expose new thread RPCs through gateway proto
- Expose AppsGateway.GetAppProfile (used by console UI for rendering app identities in thread participants/messages)

## Testing
- buf lint

Refs #67