### PR TITLE
feat(proto): add identity lookup RPCs

### DIFF
--- a/proto/agynio/api/agents/v1/agents.proto
+++ b/proto/agynio/api/agents/v1/agents.proto
@@ -15,6 +15,8 @@ service AgentsService {
   // --- Agents ---
   rpc CreateAgent(CreateAgentRequest) returns (CreateAgentResponse);
   rpc GetAgent(GetAgentRequest) returns (GetAgentResponse);
+  // Resolve an agent and organization by identity ID.
+  rpc ResolveAgentIdentity(ResolveAgentIdentityRequest) returns (ResolveAgentIdentityResponse);
   rpc UpdateAgent(UpdateAgentRequest) returns (UpdateAgentResponse);
   rpc DeleteAgent(DeleteAgentRequest) returns (DeleteAgentResponse);
   rpc ListAgents(ListAgentsRequest) returns (ListAgentsResponse);
@@ -140,6 +142,15 @@ message GetAgentRequest {
 
 message GetAgentResponse {
   Agent agent = 1;
+}
+
+message ResolveAgentIdentityRequest {
+  string identity_id = 1;
+}
+
+message ResolveAgentIdentityResponse {
+  string agent_id = 1;
+  string organization_id = 2;
 }
 
 message UpdateAgentRequest {

--- a/proto/agynio/api/apps/v1/apps.proto
+++ b/proto/agynio/api/apps/v1/apps.proto
@@ -30,6 +30,8 @@ service AppsService {
   rpc GetInstallation(GetInstallationRequest) returns (GetInstallationResponse);
   // Resolve an installation by slug within an organization.
   rpc GetInstallationBySlug(GetInstallationBySlugRequest) returns (GetInstallationBySlugResponse);
+  // Resolve an installation by identity ID within an organization.
+  rpc GetInstallationByIdentityId(GetInstallationByIdentityIdRequest) returns (GetInstallationByIdentityIdResponse);
   // List installations with optional filters.
   rpc ListInstallations(ListInstallationsRequest) returns (ListInstallationsResponse);
   // Update an installation's metadata.
@@ -197,6 +199,15 @@ message GetInstallationBySlugRequest {
 }
 
 message GetInstallationBySlugResponse {
+  Installation installation = 1;
+}
+
+message GetInstallationByIdentityIdRequest {
+  string organization_id = 1;
+  string identity_id = 2;
+}
+
+message GetInstallationByIdentityIdResponse {
   Installation installation = 1;
 }
 

--- a/proto/agynio/api/notifications/v1/notifications.proto
+++ b/proto/agynio/api/notifications/v1/notifications.proto
@@ -35,7 +35,9 @@ message PublishResponse {
   google.protobuf.Timestamp ts = 2;
 }
 
-message SubscribeRequest {}
+message SubscribeRequest {
+  repeated string rooms = 1;
+}
 
 message SubscribeResponse {
   NotificationEnvelope envelope = 1;


### PR DESCRIPTION
## Summary
- add agent identity resolution RPC and messages
- add installation lookup by identity RPC
- add rooms filter to notification subscriptions

## Testing
- buf lint

Closes #136