### PR TITLE
feat(api): expand workload observability

### DIFF
--- a/proto/agynio/api/gateway/v1/runners.proto
+++ b/proto/agynio/api/gateway/v1/runners.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package agynio.api.gateway.v1;
 
+import "agynio/api/runner/v1/runner.proto";
 import "agynio/api/runners/v1/runners.proto";
 
 option go_package = "github.com/agynio/api/gen/agynio/api/gateway/v1;gatewayv1";
@@ -20,6 +21,7 @@ service RunnersGateway {
   rpc ListWorkloadsByThread(agynio.api.runners.v1.ListWorkloadsByThreadRequest) returns (agynio.api.runners.v1.ListWorkloadsByThreadResponse);
   rpc GetWorkload(agynio.api.runners.v1.GetWorkloadRequest) returns (agynio.api.runners.v1.GetWorkloadResponse);
   rpc TouchWorkload(agynio.api.runners.v1.TouchWorkloadRequest) returns (agynio.api.runners.v1.TouchWorkloadResponse);
+  rpc StreamWorkloadLogs(agynio.api.runner.v1.StreamWorkloadLogsRequest) returns (stream agynio.api.runner.v1.StreamWorkloadLogsResponse);
 
   // --- Volumes ---
   rpc GetVolume(agynio.api.runners.v1.GetVolumeRequest) returns (agynio.api.runners.v1.GetVolumeResponse);

--- a/proto/agynio/api/runner/v1/runner.proto
+++ b/proto/agynio/api/runner/v1/runner.proto
@@ -35,7 +35,7 @@ service RunnerService {
 
   // Streaming logs/events (SSE equivalents)
   // StreamWorkloadLogs streams logs for a workload container addressed by container_name.
-  // Error contract:
+  // Error/EOF contract (returned via gRPC status codes, not in-band):
   // - NotFound for unknown workload or container
   // - OK when logs are exhausted or the container terminates with the Pod still present
   // - Unavailable when the Pod is deleted mid-stream
@@ -239,9 +239,10 @@ enum ContainerStatus {
   CONTAINER_STATUS_WAITING = 3;
 }
 
+// Mirrors agynio.api.runners.v1.Container; keep fields in sync.
 message WorkloadContainer {
   // Runtime-assigned identifier from the container runtime (audit only).
-  optional string container_id = 1;
+  string container_id = 1;
   // Stable name unique within the workload, matches the Pod container name.
   string name = 2;
   ContainerRole role = 3;
@@ -357,28 +358,32 @@ message StreamWorkloadLogsRequest {
   string workload_id = 1;
 
   bool follow = 2;
-  // Deprecated: use since_time instead.
-  int64 since = 3; // epoch seconds; 0 = unset
-  // Deprecated: use tail_lines instead.
-  uint32 tail = 4; // 0 = backend default
-  // Deprecated: retained for backward compatibility.
-  bool stdout = 5;
-  bool stderr = 6;
-  bool timestamps = 7;
+  // Deprecated: used only when since_time is unset.
+  int64 since = 3 [deprecated = true]; // epoch seconds; 0 = unset
+  // Deprecated: used only when tail_lines is unset.
+  uint32 tail = 4 [deprecated = true]; // 0 = backend default
+  // Deprecated: retained for backward compatibility; servers may ignore.
+  bool stdout = 5 [deprecated = true];
+  bool stderr = 6 [deprecated = true];
+  bool timestamps = 7 [deprecated = true];
 
-  // Stable container name within the workload.
+  // Stable container name within the workload. Required; empty -> InvalidArgument.
   string container_name = 8;
   // Number of lines from the end of the log to return (0 = backend default).
+  // When set (>0), overrides the deprecated tail field.
   uint32 tail_lines = 9;
   // Only return logs since this time (unset = all).
+  // When set, overrides the deprecated since field.
   google.protobuf.Timestamp since_time = 10;
 }
 
 message StreamWorkloadLogsResponse {
   oneof event {
     LogChunk chunk = 1;
-    LogEnd end = 2;
-    RunnerError error = 3;
+    // Deprecated: end-of-stream is indicated by a clean gRPC EOF (OK).
+    LogEnd end = 2 [deprecated = true];
+    // Deprecated: errors must be surfaced via gRPC status codes.
+    RunnerError error = 3 [deprecated = true];
   }
 }
 
@@ -387,6 +392,7 @@ message LogChunk {
   google.protobuf.Timestamp ts = 2;
 }
 
+// Deprecated: end-of-stream is indicated by gRPC EOF.
 message LogEnd {}
 
 // -------------------- Runtime events streaming --------------------

--- a/proto/agynio/api/runner/v1/runner.proto
+++ b/proto/agynio/api/runner/v1/runner.proto
@@ -34,6 +34,11 @@ service RunnerService {
   rpc PutArchive(PutArchiveRequest) returns (PutArchiveResponse);
 
   // Streaming logs/events (SSE equivalents)
+  // StreamWorkloadLogs streams logs for a workload container addressed by container_name.
+  // Error contract:
+  // - NotFound for unknown workload or container
+  // - OK when logs are exhausted or the container terminates with the Pod still present
+  // - Unavailable when the Pod is deleted mid-stream
   rpc StreamWorkloadLogs(StreamWorkloadLogsRequest) returns (stream StreamWorkloadLogsResponse);
   rpc StreamEvents(StreamEventsRequest) returns (stream StreamEventsResponse);
 
@@ -220,12 +225,42 @@ message RemoveWorkloadRequest {
 
 message RemoveWorkloadResponse {}
 
+enum ContainerRole {
+  CONTAINER_ROLE_UNSPECIFIED = 0;
+  CONTAINER_ROLE_MAIN = 1;
+  CONTAINER_ROLE_SIDECAR = 2;
+  CONTAINER_ROLE_INIT = 3;
+}
+
+enum ContainerStatus {
+  CONTAINER_STATUS_UNSPECIFIED = 0;
+  CONTAINER_STATUS_RUNNING = 1;
+  CONTAINER_STATUS_TERMINATED = 2;
+  CONTAINER_STATUS_WAITING = 3;
+}
+
+message WorkloadContainer {
+  // Runtime-assigned identifier from the container runtime (audit only).
+  optional string container_id = 1;
+  // Stable name unique within the workload, matches the Pod container name.
+  string name = 2;
+  ContainerRole role = 3;
+  string image = 4;
+  ContainerStatus status = 5;
+  optional string reason = 6;
+  optional string message = 7;
+  optional int32 exit_code = 8;
+  int32 restart_count = 9;
+  optional google.protobuf.Timestamp started_at = 10;
+  optional google.protobuf.Timestamp finished_at = 11;
+}
+
 message InspectWorkloadRequest {
   string workload_id = 1;
 }
 
-// EXACT fields used today in platform:
-// id, name, image, config_image, config_labels, mounts, state_status, state_running
+// Inspect workload details plus per-container runtime state.
+// Existing fields are preserved for backward compatibility.
 message InspectWorkloadResponse {
   string id = 1;
   string name = 2;
@@ -238,6 +273,7 @@ message InspectWorkloadResponse {
 
   string state_status = 7;
   bool state_running = 8;
+  repeated WorkloadContainer containers = 9;
 }
 
 message TargetMount {
@@ -321,11 +357,21 @@ message StreamWorkloadLogsRequest {
   string workload_id = 1;
 
   bool follow = 2;
+  // Deprecated: use since_time instead.
   int64 since = 3; // epoch seconds; 0 = unset
+  // Deprecated: use tail_lines instead.
   uint32 tail = 4; // 0 = backend default
+  // Deprecated: retained for backward compatibility.
   bool stdout = 5;
   bool stderr = 6;
   bool timestamps = 7;
+
+  // Stable container name within the workload.
+  string container_name = 8;
+  // Number of lines from the end of the log to return (0 = backend default).
+  uint32 tail_lines = 9;
+  // Only return logs since this time (unset = all).
+  google.protobuf.Timestamp since_time = 10;
 }
 
 message StreamWorkloadLogsResponse {

--- a/proto/agynio/api/runners/v1/runners.proto
+++ b/proto/agynio/api/runners/v1/runners.proto
@@ -174,7 +174,7 @@ enum ContainerStatus {
 
 message Container {
   // Runtime-assigned identifier from the container runtime (audit only).
-  optional string container_id = 1;
+  string container_id = 1;
   // Stable name unique within the workload, matches the Pod container name.
   string name = 2;
   ContainerRole role = 3;

--- a/proto/agynio/api/runners/v1/runners.proto
+++ b/proto/agynio/api/runners/v1/runners.proto
@@ -173,11 +173,19 @@ enum ContainerStatus {
 }
 
 message Container {
-  string container_id = 1;
+  // Runtime-assigned identifier from the container runtime (audit only).
+  optional string container_id = 1;
+  // Stable name unique within the workload, matches the Pod container name.
   string name = 2;
   ContainerRole role = 3;
   string image = 4;
   ContainerStatus status = 5;
+  optional string reason = 6;
+  optional string message = 7;
+  optional int32 exit_code = 8;
+  int32 restart_count = 9;
+  optional google.protobuf.Timestamp started_at = 10;
+  optional google.protobuf.Timestamp finished_at = 11;
 }
 
 message Workload {


### PR DESCRIPTION
## Summary
- expand runners.v1 Container fields with reason/exit/restart/timestamps
- add runner.v1 InspectWorkload container runtime details and log streaming params
- expose StreamWorkloadLogs on RunnersGateway

## Testing
- buf lint

## Issue
- Relates to agynio/runners#33