### PR TITLE
feat(metering): extend usage query

### DIFF
--- a/proto/agynio/api/metering/v1/metering.proto
+++ b/proto/agynio/api/metering/v1/metering.proto
@@ -43,12 +43,16 @@ message QueryUsageRequest {
   map<string, string> label_filters = 5;
   string group_by = 6;
   Granularity granularity = 7;
+  string time_zone = 8;
 }
 
 enum Granularity {
   GRANULARITY_UNSPECIFIED = 0;
   GRANULARITY_TOTAL = 1;
   GRANULARITY_DAY = 2;
+  GRANULARITY_FIVE_MINUTES = 3;
+  GRANULARITY_HOUR = 4;
+  GRANULARITY_SIX_HOURS = 5;
 }
 
 message UsageBucket {

--- a/proto/agynio/api/metering/v1/metering.proto
+++ b/proto/agynio/api/metering/v1/metering.proto
@@ -43,6 +43,8 @@ message QueryUsageRequest {
   map<string, string> label_filters = 5;
   string group_by = 6;
   Granularity granularity = 7;
+  // IANA time zone ID. Empty defaults to UTC. Applies to bucket alignment for
+  // non-total granularities.
   string time_zone = 8;
 }
 


### PR DESCRIPTION
## Summary
- add time_zone to QueryUsageRequest
- extend Granularity with 5m/hour/6h values

## Testing
- buf lint

Refs #129