### PR TITLE
Add username search and profile APIs

### DIFF
--- a/proto/agynio/api/gateway/v1/organizations.proto
+++ b/proto/agynio/api/gateway/v1/organizations.proto
@@ -23,4 +23,7 @@ service OrganizationsGateway {
   rpc UpdateMembershipRole(agynio.api.organizations.v1.UpdateMembershipRoleRequest) returns (agynio.api.organizations.v1.UpdateMembershipRoleResponse);
   rpc ListMembers(agynio.api.organizations.v1.ListMembersRequest) returns (agynio.api.organizations.v1.ListMembersResponse);
   rpc ListMyMemberships(agynio.api.organizations.v1.ListMyMembershipsRequest) returns (agynio.api.organizations.v1.ListMyMembershipsResponse);
+
+  // --- Org Nicknames ---
+  rpc SetMyOrgNickname(agynio.api.organizations.v1.SetMyOrgNicknameRequest) returns (agynio.api.organizations.v1.SetMyOrgNicknameResponse);
 }

--- a/proto/agynio/api/gateway/v1/users.proto
+++ b/proto/agynio/api/gateway/v1/users.proto
@@ -9,6 +9,10 @@ option go_package = "github.com/agynio/api/gen/agynio/api/gateway/v1;gatewayv1";
 service UsersGateway {
   // --- Current User ---
   rpc GetMe(agynio.api.users.v1.GetMeRequest) returns (agynio.api.users.v1.GetMeResponse);
+  rpc UpdateMe(agynio.api.users.v1.UpdateMeRequest) returns (agynio.api.users.v1.UpdateMeResponse);
+
+  // --- User Directory ---
+  rpc SearchUsers(agynio.api.users.v1.SearchUsersRequest) returns (agynio.api.users.v1.SearchUsersResponse);
 
   // --- Admin User Management ---
   rpc CreateUser(agynio.api.users.v1.CreateUserRequest) returns (agynio.api.users.v1.CreateUserResponse);

--- a/proto/agynio/api/organizations/v1/organizations.proto
+++ b/proto/agynio/api/organizations/v1/organizations.proto
@@ -26,6 +26,9 @@ service OrganizationsService {
   rpc UpdateMembershipRole(UpdateMembershipRoleRequest) returns (UpdateMembershipRoleResponse);
   rpc ListMembers(ListMembersRequest) returns (ListMembersResponse);
   rpc ListMyMemberships(ListMyMembershipsRequest) returns (ListMyMembershipsResponse);
+
+  // --- Org Nicknames ---
+  rpc SetMyOrgNickname(SetMyOrgNicknameRequest) returns (SetMyOrgNicknameResponse);
 }
 
 // ===========================================================================
@@ -209,3 +212,14 @@ message ListMyMembershipsResponse {
   repeated Membership memberships = 1;
   string next_page_token = 2;
 }
+
+// ===========================================================================
+// SetMyOrgNickname
+// ===========================================================================
+
+message SetMyOrgNicknameRequest {
+  string organization_id = 1; // UUID
+  string nickname = 2;
+}
+
+message SetMyOrgNicknameResponse {}

--- a/proto/agynio/api/organizations/v1/organizations.proto
+++ b/proto/agynio/api/organizations/v1/organizations.proto
@@ -28,6 +28,7 @@ service OrganizationsService {
   rpc ListMyMemberships(ListMyMembershipsRequest) returns (ListMyMembershipsResponse);
 
   // --- Org Nicknames ---
+  // Self-service org nickname update for the calling identity.
   rpc SetMyOrgNickname(SetMyOrgNicknameRequest) returns (SetMyOrgNicknameResponse);
 }
 
@@ -219,6 +220,7 @@ message ListMyMembershipsResponse {
 
 message SetMyOrgNicknameRequest {
   string organization_id = 1; // UUID
+  // Organization-scoped nickname for the caller.
   string nickname = 2;
 }
 

--- a/proto/agynio/api/users/v1/users.proto
+++ b/proto/agynio/api/users/v1/users.proto
@@ -19,6 +19,10 @@ service UsersService {
 
   // --- Current User ---
   rpc GetMe(GetMeRequest) returns (GetMeResponse);
+  rpc UpdateMe(UpdateMeRequest) returns (UpdateMeResponse);
+
+  // --- User Directory ---
+  rpc SearchUsers(SearchUsersRequest) returns (SearchUsersResponse);
 
   // --- Admin User Management ---
   rpc ListUsers(ListUsersRequest) returns (ListUsersResponse);
@@ -63,6 +67,7 @@ message User {
   string email = 4;
   string photo_url = 5;
   string nickname = 6;
+  string username = 7;
 }
 
 // ===========================================================================
@@ -86,6 +91,7 @@ message ResolveOrCreateUserRequest {
   string name = 2;
   string email = 3;
   string photo_url = 4;
+  optional string preferred_username = 5;
 }
 
 message ResolveOrCreateUserResponse {
@@ -141,6 +147,7 @@ message UpdateUserRequest {
   optional string photo_url = 4;
   optional string nickname = 5;
   optional ClusterRole cluster_role = 6;
+  optional string username = 7;
 }
 
 message UpdateUserResponse {
@@ -156,6 +163,40 @@ message GetMeRequest {}
 message GetMeResponse {
   User user = 1;
   ClusterRole cluster_role = 2;
+}
+
+// ===========================================================================
+// UpdateMe
+// ===========================================================================
+
+message UpdateMeRequest {
+  optional string name = 1;
+  optional string username = 2;
+}
+
+message UpdateMeResponse {
+  User user = 1;
+  ClusterRole cluster_role = 2;
+}
+
+// ===========================================================================
+// SearchUsers
+// ===========================================================================
+
+message UserDirectoryEntry {
+  string identity_id = 1;
+  string username = 2;
+  string name = 3;
+  string photo_url = 4;
+}
+
+message SearchUsersRequest {
+  string prefix = 1;
+  int32 limit = 2;
+}
+
+message SearchUsersResponse {
+  repeated UserDirectoryEntry users = 1;
 }
 
 // ===========================================================================
@@ -182,6 +223,7 @@ message CreateUserRequest {
   optional string nickname = 3;
   optional string photo_url = 4;
   ClusterRole cluster_role = 5;
+  optional string username = 6;
 }
 
 message CreateUserResponse {

--- a/proto/agynio/api/users/v1/users.proto
+++ b/proto/agynio/api/users/v1/users.proto
@@ -19,6 +19,8 @@ service UsersService {
 
   // --- Current User ---
   rpc GetMe(GetMeRequest) returns (GetMeResponse);
+  // Updates cluster-wide profile fields (name/username). Org-scoped
+  // nicknames are managed via OrganizationsService.SetMyOrgNickname.
   rpc UpdateMe(UpdateMeRequest) returns (UpdateMeResponse);
 
   // --- User Directory ---
@@ -66,7 +68,9 @@ message User {
   string name = 3;
   string email = 4;
   string photo_url = 5;
+  // Organization-scoped nickname (set via OrganizationsService.SetMyOrgNickname).
   string nickname = 6;
+  // Cluster-wide username. May be empty for existing users until set.
   string username = 7;
 }
 
@@ -171,6 +175,7 @@ message GetMeResponse {
 
 message UpdateMeRequest {
   optional string name = 1;
+  // Cluster-wide username. Org-scoped nicknames are set via OrganizationsService.SetMyOrgNickname.
   optional string username = 2;
 }
 
@@ -192,6 +197,7 @@ message UserDirectoryEntry {
 
 message SearchUsersRequest {
   string prefix = 1;
+  // Defaults to 10 when unset or zero. Max 20.
   int32 limit = 2;
 }
 


### PR DESCRIPTION
## Summary
- add username to user contracts and provisioning input
- expose self-service profile update and user directory search
- add org nickname setter endpoint in organizations gateway

## Testing
- buf lint
- buf breaking --against '.git#branch=main'

Refs #140