### PR TITLE
feat(egress): add gateway proto contracts

### DIFF
--- a/proto/agynio/api/egress/v1/egress.proto
+++ b/proto/agynio/api/egress/v1/egress.proto
@@ -84,23 +84,11 @@ message EgressRule {
   EgressRuleEffect effect = 6;
 }
 
-// Internal EgressRule representation with control-plane resource identifiers.
-message InternalEgressRule {
-  EgressRule egress_rule = 1;
-  string openziti_service_id = 2;
-}
-
 // Attachment binding an egress rule to an agent.
 message EgressRuleAttachment {
   EntityMeta meta = 1;
   string rule_id = 2;
   string agent_id = 3;
-}
-
-// Internal EgressRuleAttachment representation with control-plane resource identifiers.
-message InternalEgressRuleAttachment {
-  EgressRuleAttachment egress_rule_attachment = 1;
-  string openziti_dial_policy_id = 2;
 }
 
 message CreateEgressRuleRequest {
@@ -185,7 +173,7 @@ message ListEgressRulesByAgentRequest {
 }
 
 message ListEgressRulesByAgentResponse {
-  repeated InternalEgressRule egress_rules = 1;
+  repeated EgressRule egress_rules = 1;
 }
 
 message CountRulesReferencingSecretRequest {

--- a/proto/agynio/api/egress/v1/egress.proto
+++ b/proto/agynio/api/egress/v1/egress.proto
@@ -1,0 +1,188 @@
+syntax = "proto3";
+
+package agynio.api.egress.v1;
+
+import "google/protobuf/timestamp.proto";
+
+option go_package = "github.com/agynio/api/gen/agynio/api/egress/v1;egressv1";
+
+// EgressRulesService manages egress rules and agent attachments.
+service EgressRulesService {
+  // --- Egress Rules ---
+  rpc CreateEgressRule(CreateEgressRuleRequest) returns (CreateEgressRuleResponse);
+  rpc GetEgressRule(GetEgressRuleRequest) returns (GetEgressRuleResponse);
+  rpc ListEgressRules(ListEgressRulesRequest) returns (ListEgressRulesResponse);
+  rpc UpdateEgressRule(UpdateEgressRuleRequest) returns (UpdateEgressRuleResponse);
+  rpc DeleteEgressRule(DeleteEgressRuleRequest) returns (DeleteEgressRuleResponse);
+
+  // --- Egress Rule Attachments ---
+  rpc CreateEgressRuleAttachment(CreateEgressRuleAttachmentRequest) returns (CreateEgressRuleAttachmentResponse);
+  rpc DeleteEgressRuleAttachment(DeleteEgressRuleAttachmentRequest) returns (DeleteEgressRuleAttachmentResponse);
+  rpc ListEgressRuleAttachments(ListEgressRuleAttachmentsRequest) returns (ListEgressRuleAttachmentsResponse);
+
+  // --- Internal ---
+  rpc ListEgressRulesByAgent(ListEgressRulesByAgentRequest) returns (ListEgressRulesByAgentResponse);
+  rpc CountRulesReferencingSecret(CountRulesReferencingSecretRequest) returns (CountRulesReferencingSecretResponse);
+}
+
+// Metadata shared by egress resources.
+message EntityMeta {
+  string id = 1;
+  google.protobuf.Timestamp created_at = 2;
+  google.protobuf.Timestamp updated_at = 3;
+}
+
+// Effect to apply to a request matching an egress rule.
+enum EgressRuleAction {
+  EGRESS_RULE_ACTION_UNSPECIFIED = 0;
+  EGRESS_RULE_ACTION_ALLOW = 1;
+  EGRESS_RULE_ACTION_DENY = 2;
+}
+
+// Authentication scheme used when emitting an injected header.
+enum HeaderAuthScheme {
+  HEADER_AUTH_SCHEME_UNSPECIFIED = 0;
+  HEADER_AUTH_SCHEME_BEARER = 1;
+  HEADER_AUTH_SCHEME_BASIC = 2;
+}
+
+// Request attributes matched by an egress rule.
+message EgressRuleMatcher {
+  // Hostname pattern. Examples: "api.github.com", "*.github.com".
+  string domain_pattern = 1;
+  // Destination ports to intercept. Empty means service default ports.
+  repeated int32 ports = 2;
+  // HTTP methods the rule applies to. Empty means any method.
+  repeated string methods = 3;
+  // Glob over the request path. Empty means any path.
+  string path_pattern = 4;
+}
+
+// Header credential injected by the egress gateway.
+message EgressRuleHeader {
+  string name = 1;
+  HeaderAuthScheme scheme = 2;
+  oneof credential {
+    string value = 3;
+    string secret_id = 4;
+  }
+}
+
+// Behavior to apply to requests matching an egress rule.
+message EgressRuleEffect {
+  optional EgressRuleAction action = 1;
+  repeated EgressRuleHeader inject = 2;
+}
+
+// Rule mediating outbound HTTP/HTTPS traffic from agent workloads.
+message EgressRule {
+  EntityMeta meta = 1;
+  string organization_id = 2;
+  string name = 3;
+  string description = 4;
+  EgressRuleMatcher matcher = 5;
+  EgressRuleEffect effect = 6;
+  string openziti_service_id = 7;
+}
+
+// Attachment binding an egress rule to an agent.
+message EgressRuleAttachment {
+  EntityMeta meta = 1;
+  string rule_id = 2;
+  string agent_id = 3;
+  string openziti_dial_policy_id = 4;
+}
+
+message CreateEgressRuleRequest {
+  string organization_id = 1;
+  string name = 2;
+  string description = 3;
+  EgressRuleMatcher matcher = 4;
+  EgressRuleEffect effect = 5;
+}
+
+message CreateEgressRuleResponse {
+  EgressRule egress_rule = 1;
+}
+
+message GetEgressRuleRequest {
+  string id = 1;
+}
+
+message GetEgressRuleResponse {
+  EgressRule egress_rule = 1;
+}
+
+message ListEgressRulesRequest {
+  string organization_id = 1;
+  int32 page_size = 2;
+  string page_token = 3;
+}
+
+message ListEgressRulesResponse {
+  repeated EgressRule egress_rules = 1;
+  string next_page_token = 2;
+}
+
+message UpdateEgressRuleRequest {
+  string id = 1;
+  optional string name = 2;
+  optional string description = 3;
+  optional EgressRuleMatcher matcher = 4;
+  optional EgressRuleEffect effect = 5;
+}
+
+message UpdateEgressRuleResponse {
+  EgressRule egress_rule = 1;
+}
+
+message DeleteEgressRuleRequest {
+  string id = 1;
+}
+
+message DeleteEgressRuleResponse {}
+
+message CreateEgressRuleAttachmentRequest {
+  string rule_id = 1;
+  string agent_id = 2;
+}
+
+message CreateEgressRuleAttachmentResponse {
+  EgressRuleAttachment egress_rule_attachment = 1;
+}
+
+message DeleteEgressRuleAttachmentRequest {
+  string id = 1;
+}
+
+message DeleteEgressRuleAttachmentResponse {}
+
+message ListEgressRuleAttachmentsRequest {
+  string organization_id = 1;
+  optional string rule_id = 2;
+  optional string agent_id = 3;
+  int32 page_size = 4;
+  string page_token = 5;
+}
+
+message ListEgressRuleAttachmentsResponse {
+  repeated EgressRuleAttachment egress_rule_attachments = 1;
+  string next_page_token = 2;
+}
+
+message ListEgressRulesByAgentRequest {
+  string agent_id = 1;
+}
+
+message ListEgressRulesByAgentResponse {
+  repeated EgressRule egress_rules = 1;
+}
+
+message CountRulesReferencingSecretRequest {
+  string secret_id = 1;
+}
+
+message CountRulesReferencingSecretResponse {
+  int32 count = 1;
+  repeated string egress_rule_ids = 2;
+}

--- a/proto/agynio/api/egress/v1/egress.proto
+++ b/proto/agynio/api/egress/v1/egress.proto
@@ -82,7 +82,12 @@ message EgressRule {
   string description = 4;
   EgressRuleMatcher matcher = 5;
   EgressRuleEffect effect = 6;
-  string openziti_service_id = 7;
+}
+
+// Internal EgressRule representation with control-plane resource identifiers.
+message InternalEgressRule {
+  EgressRule egress_rule = 1;
+  string openziti_service_id = 2;
 }
 
 // Attachment binding an egress rule to an agent.
@@ -90,7 +95,12 @@ message EgressRuleAttachment {
   EntityMeta meta = 1;
   string rule_id = 2;
   string agent_id = 3;
-  string openziti_dial_policy_id = 4;
+}
+
+// Internal EgressRuleAttachment representation with control-plane resource identifiers.
+message InternalEgressRuleAttachment {
+  EgressRuleAttachment egress_rule_attachment = 1;
+  string openziti_dial_policy_id = 2;
 }
 
 message CreateEgressRuleRequest {
@@ -175,7 +185,7 @@ message ListEgressRulesByAgentRequest {
 }
 
 message ListEgressRulesByAgentResponse {
-  repeated EgressRule egress_rules = 1;
+  repeated InternalEgressRule egress_rules = 1;
 }
 
 message CountRulesReferencingSecretRequest {

--- a/proto/agynio/api/gateway/v1/egress.proto
+++ b/proto/agynio/api/gateway/v1/egress.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+package agynio.api.gateway.v1;
+
+import "agynio/api/egress/v1/egress.proto";
+
+option go_package = "github.com/agynio/api/gen/agynio/api/gateway/v1;gatewayv1";
+
+service EgressRulesGateway {
+  // --- Egress Rules ---
+  rpc CreateEgressRule(agynio.api.egress.v1.CreateEgressRuleRequest) returns (agynio.api.egress.v1.CreateEgressRuleResponse);
+  rpc GetEgressRule(agynio.api.egress.v1.GetEgressRuleRequest) returns (agynio.api.egress.v1.GetEgressRuleResponse);
+  rpc ListEgressRules(agynio.api.egress.v1.ListEgressRulesRequest) returns (agynio.api.egress.v1.ListEgressRulesResponse);
+  rpc UpdateEgressRule(agynio.api.egress.v1.UpdateEgressRuleRequest) returns (agynio.api.egress.v1.UpdateEgressRuleResponse);
+  rpc DeleteEgressRule(agynio.api.egress.v1.DeleteEgressRuleRequest) returns (agynio.api.egress.v1.DeleteEgressRuleResponse);
+
+  // --- Egress Rule Attachments ---
+  rpc CreateEgressRuleAttachment(agynio.api.egress.v1.CreateEgressRuleAttachmentRequest) returns (agynio.api.egress.v1.CreateEgressRuleAttachmentResponse);
+  rpc DeleteEgressRuleAttachment(agynio.api.egress.v1.DeleteEgressRuleAttachmentRequest) returns (agynio.api.egress.v1.DeleteEgressRuleAttachmentResponse);
+  rpc ListEgressRuleAttachments(agynio.api.egress.v1.ListEgressRuleAttachmentsRequest) returns (agynio.api.egress.v1.ListEgressRuleAttachmentsResponse);
+}

--- a/proto/agynio/api/runner/v1/runner.proto
+++ b/proto/agynio/api/runner/v1/runner.proto
@@ -102,6 +102,12 @@ message VolumeMount {
   bool read_only = 3;
 }
 
+// InlineFileMount references a file supplied through
+// StartWorkloadRequest.inline_files.
+message InlineFileMount {
+  string path = 1;
+}
+
 // ContainerSpec describes a single container within a workload.
 message ContainerSpec {
   string image = 1;
@@ -120,6 +126,9 @@ message ContainerSpec {
   // Example values: "privileged", "dind".
   repeated string required_capabilities = 8;
 
+  // Inline files mounted read-only into this container.
+  repeated InlineFileMount inline_file_mounts = 9;
+
   // Backend-specific optional properties.
   map<string, string> additional_properties = 100;
 }
@@ -137,6 +146,18 @@ message ImagePullCredential {
   string registry = 1;
   string username = 2;
   string password = 3;
+}
+
+// NetworkPolicy describes workload egress restrictions to materialize.
+message NetworkPolicy {
+  // CIDRs the workload is allowed to reach via egress.
+  repeated string allow_cidrs = 1;
+
+  // CIDRs the workload is forbidden to reach via egress.
+  repeated string block_cidrs = 2;
+
+  // Allows UDP/53 to cluster DNS regardless of CIDRs.
+  bool allow_cluster_dns = 3;
 }
 
 // A workload is a main container plus optional sidecars.
@@ -164,6 +185,13 @@ message StartWorkloadRequest {
   // Runner-level capabilities required by the workload. Free-form strings
   // (e.g., "privileged", "dind").
   repeated string capabilities = 9;
+
+  // Small files keyed by absolute container path and mounted read-only into
+  // containers that list the path in inline_file_mounts.
+  map<string, bytes> inline_files = 10;
+
+  // Optional egress restrictions for the workload.
+  NetworkPolicy network_policy = 11;
 
   map<string, string> additional_properties = 100;
 }

--- a/proto/agynio/api/runner/v1/runner.proto
+++ b/proto/agynio/api/runner/v1/runner.proto
@@ -102,6 +102,12 @@ message VolumeMount {
   bool read_only = 3;
 }
 
+// InlineFileMount references a file supplied through
+// StartWorkloadRequest.inline_files.
+message InlineFileMount {
+  string path = 1;
+}
+
 // ContainerSpec describes a single container within a workload.
 message ContainerSpec {
   string image = 1;
@@ -119,6 +125,9 @@ message ContainerSpec {
   // Required capabilities that the backend must satisfy for this container.
   // Example values: "privileged", "dind".
   repeated string required_capabilities = 8;
+
+  // Inline files mounted read-only into this container.
+  repeated InlineFileMount inline_file_mounts = 9;
 
   // Backend-specific optional properties.
   map<string, string> additional_properties = 100;
@@ -166,7 +175,7 @@ message StartWorkloadRequest {
   repeated string capabilities = 9;
 
   // Small files keyed by absolute container path and mounted read-only into
-  // workload containers.
+  // containers that list the path in inline_file_mounts.
   map<string, bytes> inline_files = 10;
 
   map<string, string> additional_properties = 100;

--- a/proto/agynio/api/runner/v1/runner.proto
+++ b/proto/agynio/api/runner/v1/runner.proto
@@ -102,12 +102,6 @@ message VolumeMount {
   bool read_only = 3;
 }
 
-// InlineFileMount references a file supplied through
-// StartWorkloadRequest.inline_files.
-message InlineFileMount {
-  string path = 1;
-}
-
 // ContainerSpec describes a single container within a workload.
 message ContainerSpec {
   string image = 1;
@@ -126,9 +120,6 @@ message ContainerSpec {
   // Example values: "privileged", "dind".
   repeated string required_capabilities = 8;
 
-  // Inline files mounted read-only into this container.
-  repeated InlineFileMount inline_file_mounts = 9;
-
   // Backend-specific optional properties.
   map<string, string> additional_properties = 100;
 }
@@ -146,18 +137,6 @@ message ImagePullCredential {
   string registry = 1;
   string username = 2;
   string password = 3;
-}
-
-// NetworkPolicy describes workload egress restrictions to materialize.
-message NetworkPolicy {
-  // CIDRs the workload is allowed to reach via egress.
-  repeated string allow_cidrs = 1;
-
-  // CIDRs the workload is forbidden to reach via egress.
-  repeated string block_cidrs = 2;
-
-  // Allows UDP/53 to cluster DNS regardless of CIDRs.
-  bool allow_cluster_dns = 3;
 }
 
 // A workload is a main container plus optional sidecars.
@@ -187,11 +166,8 @@ message StartWorkloadRequest {
   repeated string capabilities = 9;
 
   // Small files keyed by absolute container path and mounted read-only into
-  // containers that list the path in inline_file_mounts.
+  // workload containers.
   map<string, bytes> inline_files = 10;
-
-  // Optional egress restrictions for the workload.
-  NetworkPolicy network_policy = 11;
 
   map<string, string> additional_properties = 100;
 }

--- a/proto/agynio/api/runners/v1/runners.proto
+++ b/proto/agynio/api/runners/v1/runners.proto
@@ -84,12 +84,6 @@ message Runner {
   string openziti_service_name = 7;
   // Capabilities supported by this runner. Free-form strings (e.g., "privileged", "dind").
   repeated string capabilities = 8;
-  // Cluster pod CIDR used to compute workload network policies.
-  string cluster_pod_cidr = 9;
-  // Cluster service CIDR used to compute workload network policies.
-  string cluster_service_cidr = 10;
-  // Additional internal CIDRs to block from agent workload egress.
-  repeated string additional_excluded_cidrs = 11;
 }
 
 message RegisterRunnerRequest {
@@ -98,12 +92,6 @@ message RegisterRunnerRequest {
   map<string, string> labels = 3;
   // Capabilities supported by this runner. Free-form strings (e.g., "privileged", "dind").
   repeated string capabilities = 4;
-  // Cluster pod CIDR. Required for external runners.
-  string cluster_pod_cidr = 5;
-  // Cluster service CIDR. Required for external runners.
-  string cluster_service_cidr = 6;
-  // Additional internal CIDRs to block from agent workload egress.
-  repeated string additional_excluded_cidrs = 7;
 }
 
 message RegisterRunnerResponse {
@@ -137,10 +125,6 @@ message UpdateRunnerRequest {
   map<string, string> labels = 3;
   // Capabilities replace the existing list; an empty list clears all capabilities.
   repeated string capabilities = 4;
-  optional string cluster_pod_cidr = 5;
-  optional string cluster_service_cidr = 6;
-  // Additional excluded CIDRs replace the existing list; an empty list clears them.
-  repeated string additional_excluded_cidrs = 7;
 }
 
 message UpdateRunnerResponse {

--- a/proto/agynio/api/runners/v1/runners.proto
+++ b/proto/agynio/api/runners/v1/runners.proto
@@ -84,6 +84,12 @@ message Runner {
   string openziti_service_name = 7;
   // Capabilities supported by this runner. Free-form strings (e.g., "privileged", "dind").
   repeated string capabilities = 8;
+  // Cluster pod CIDR used to compute workload network policies.
+  string cluster_pod_cidr = 9;
+  // Cluster service CIDR used to compute workload network policies.
+  string cluster_service_cidr = 10;
+  // Additional internal CIDRs to block from agent workload egress.
+  repeated string additional_excluded_cidrs = 11;
 }
 
 message RegisterRunnerRequest {
@@ -92,6 +98,12 @@ message RegisterRunnerRequest {
   map<string, string> labels = 3;
   // Capabilities supported by this runner. Free-form strings (e.g., "privileged", "dind").
   repeated string capabilities = 4;
+  // Cluster pod CIDR. Required for external runners.
+  string cluster_pod_cidr = 5;
+  // Cluster service CIDR. Required for external runners.
+  string cluster_service_cidr = 6;
+  // Additional internal CIDRs to block from agent workload egress.
+  repeated string additional_excluded_cidrs = 7;
 }
 
 message RegisterRunnerResponse {
@@ -125,6 +137,10 @@ message UpdateRunnerRequest {
   map<string, string> labels = 3;
   // Capabilities replace the existing list; an empty list clears all capabilities.
   repeated string capabilities = 4;
+  optional string cluster_pod_cidr = 5;
+  optional string cluster_service_cidr = 6;
+  // Additional excluded CIDRs replace the existing list; an empty list clears them.
+  repeated string additional_excluded_cidrs = 7;
 }
 
 message UpdateRunnerResponse {

--- a/proto/agynio/api/secrets/v1/secrets.proto
+++ b/proto/agynio/api/secrets/v1/secrets.proto
@@ -30,6 +30,8 @@ service SecretsService {
   // --- Resolution ---
   // Resolve a secret to its actual value by fetching from the external provider.
   rpc ResolveSecret(ResolveSecretRequest) returns (ResolveSecretResponse);
+  // Verify that a secret exists without resolving its value.
+  rpc ResolveSecretExists(ResolveSecretExistsRequest) returns (ResolveSecretExistsResponse);
 
   // --- Image Pull Secrets ---
   rpc CreateImagePullSecret(CreateImagePullSecretRequest) returns (CreateImagePullSecretResponse);
@@ -216,6 +218,15 @@ message ResolveSecretRequest {
 
 message ResolveSecretResponse {
   string value = 1; // The resolved secret value from the external provider
+}
+
+message ResolveSecretExistsRequest {
+  string id = 1; // UUID of the Secret to check
+}
+
+message ResolveSecretExistsResponse {
+  bool exists = 1;
+  string organization_id = 2;
 }
 
 // ===========================================================================


### PR DESCRIPTION
## Summary
- Add `agynio.api.egress.v1` proto contracts for egress rules, rule matchers/effects/header injection, attachments, external CRUD, and internal lookup/reference-check RPCs.
- Add `EgressRulesGateway` facade proto for the externally exposed methods only.
- Extend runner workload contracts with inline-file mounts, `StartWorkloadRequest.inline_files`, and workload `NetworkPolicy`.
- Add runner cluster CIDR fields and the internal Secrets `ResolveSecretExists` RPC required by the egress gateway v1 architecture.

## Repo discovery
- API protos: `agynio/api`
- Gateway routing follow-up repo: `agynio/gateway`

Closes #143

## Validation
- `buf build`
- `buf lint`
- `buf breaking --against '.git#branch=main'`
- `git diff --check`