### PR TITLE
feat: add egress gateway ziti API support

### DIFF
--- a/proto/agynio/api/ziti_management/v1/ziti_management.proto
+++ b/proto/agynio/api/ziti_management/v1/ziti_management.proto
@@ -75,6 +75,7 @@ enum ServiceType {
   SERVICE_TYPE_LLM_PROXY = 4;
   SERVICE_TYPE_TRACING = 5;
   SERVICE_TYPE_RUNNERS = 6;
+  SERVICE_TYPE_EGRESS_GATEWAY = 7;
   reserved 3;
   reserved "SERVICE_TYPE_RUNNER";
 }
@@ -123,6 +124,12 @@ message HostV1Config {
   string protocol = 1;
   string address = 2;
   int32 port = 3;
+  bool forward_protocol = 4;
+  bool forward_address = 5;
+  bool forward_port = 6;
+  repeated string allowed_protocols = 7;
+  repeated string allowed_addresses = 8;
+  repeated PortRange allowed_port_ranges = 9;
 }
 
 // OpenZiti intercept.v1 config — tells dialing tunnelers which address to intercept.


### PR DESCRIPTION
## Summary
- Adds `SERVICE_TYPE_EGRESS_GATEWAY` to Ziti Management API service identity types.
- Extends `HostV1Config` for OpenZiti `host.v1` forwarding with `forward_protocol`, `forward_address`, `forward_port`, and allowed protocol/address/port range constraints.

## Issue
Part of agynio/architecture#151.

## Test & Lint Summary
- `buf lint`: passed with no errors.
- `buf breaking --against 'https://github.com/agynio/api.git#branch=main'`: passed with no breaking changes.
- Tests: not applicable for proto-only repository.
