### PR TITLE
feat(api): add private networks contracts

### DIFF
--- a/proto/agynio/api/gateway/v1/groups.proto
+++ b/proto/agynio/api/gateway/v1/groups.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+
+package agynio.api.gateway.v1;
+
+import "agynio/api/groups/v1/groups.proto";
+
+option go_package = "github.com/agynio/api/gen/agynio/api/gateway/v1;gatewayv1";
+
+service GroupsGateway {
+  // --- Groups ---
+  rpc CreateGroup(agynio.api.groups.v1.CreateGroupRequest) returns (agynio.api.groups.v1.CreateGroupResponse);
+  rpc GetGroup(agynio.api.groups.v1.GetGroupRequest) returns (agynio.api.groups.v1.GetGroupResponse);
+  rpc ListGroups(agynio.api.groups.v1.ListGroupsRequest) returns (agynio.api.groups.v1.ListGroupsResponse);
+  rpc UpdateGroup(agynio.api.groups.v1.UpdateGroupRequest) returns (agynio.api.groups.v1.UpdateGroupResponse);
+  rpc DeleteGroup(agynio.api.groups.v1.DeleteGroupRequest) returns (agynio.api.groups.v1.DeleteGroupResponse);
+
+  // --- Memberships ---
+  rpc AddMember(agynio.api.groups.v1.AddMemberRequest) returns (agynio.api.groups.v1.AddMemberResponse);
+  rpc RemoveMember(agynio.api.groups.v1.RemoveMemberRequest) returns (agynio.api.groups.v1.RemoveMemberResponse);
+  rpc ListMembers(agynio.api.groups.v1.ListMembersRequest) returns (agynio.api.groups.v1.ListMembersResponse);
+  rpc ListMemberGroups(agynio.api.groups.v1.ListMemberGroupsRequest) returns (agynio.api.groups.v1.ListMemberGroupsResponse);
+}

--- a/proto/agynio/api/gateway/v1/networks.proto
+++ b/proto/agynio/api/gateway/v1/networks.proto
@@ -1,0 +1,34 @@
+syntax = "proto3";
+
+package agynio.api.gateway.v1;
+
+import "agynio/api/networks/v1/networks.proto";
+
+option go_package = "github.com/agynio/api/gen/agynio/api/gateway/v1;gatewayv1";
+
+service NetworksGateway {
+  // --- Networks ---
+  rpc CreateNetwork(agynio.api.networks.v1.CreateNetworkRequest) returns (agynio.api.networks.v1.CreateNetworkResponse);
+  rpc GetNetwork(agynio.api.networks.v1.GetNetworkRequest) returns (agynio.api.networks.v1.GetNetworkResponse);
+  rpc ListNetworks(agynio.api.networks.v1.ListNetworksRequest) returns (agynio.api.networks.v1.ListNetworksResponse);
+  rpc UpdateNetwork(agynio.api.networks.v1.UpdateNetworkRequest) returns (agynio.api.networks.v1.UpdateNetworkResponse);
+  rpc DeleteNetwork(agynio.api.networks.v1.DeleteNetworkRequest) returns (agynio.api.networks.v1.DeleteNetworkResponse);
+
+  // --- Tunnel Credentials ---
+  rpc CreateTunnelCredential(agynio.api.networks.v1.CreateTunnelCredentialRequest) returns (agynio.api.networks.v1.CreateTunnelCredentialResponse);
+  rpc GetTunnelCredential(agynio.api.networks.v1.GetTunnelCredentialRequest) returns (agynio.api.networks.v1.GetTunnelCredentialResponse);
+  rpc ListTunnelCredentials(agynio.api.networks.v1.ListTunnelCredentialsRequest) returns (agynio.api.networks.v1.ListTunnelCredentialsResponse);
+  rpc DeleteTunnelCredential(agynio.api.networks.v1.DeleteTunnelCredentialRequest) returns (agynio.api.networks.v1.DeleteTunnelCredentialResponse);
+
+  // --- Private Resources ---
+  rpc CreatePrivateResource(agynio.api.networks.v1.CreatePrivateResourceRequest) returns (agynio.api.networks.v1.CreatePrivateResourceResponse);
+  rpc GetPrivateResource(agynio.api.networks.v1.GetPrivateResourceRequest) returns (agynio.api.networks.v1.GetPrivateResourceResponse);
+  rpc ListPrivateResources(agynio.api.networks.v1.ListPrivateResourcesRequest) returns (agynio.api.networks.v1.ListPrivateResourcesResponse);
+  rpc UpdatePrivateResource(agynio.api.networks.v1.UpdatePrivateResourceRequest) returns (agynio.api.networks.v1.UpdatePrivateResourceResponse);
+  rpc DeletePrivateResource(agynio.api.networks.v1.DeletePrivateResourceRequest) returns (agynio.api.networks.v1.DeletePrivateResourceResponse);
+
+  // --- Private Resource Access ---
+  rpc CreatePrivateResourceAccess(agynio.api.networks.v1.CreatePrivateResourceAccessRequest) returns (agynio.api.networks.v1.CreatePrivateResourceAccessResponse);
+  rpc DeletePrivateResourceAccess(agynio.api.networks.v1.DeletePrivateResourceAccessRequest) returns (agynio.api.networks.v1.DeletePrivateResourceAccessResponse);
+  rpc ListPrivateResourceAccess(agynio.api.networks.v1.ListPrivateResourceAccessRequest) returns (agynio.api.networks.v1.ListPrivateResourceAccessResponse);
+}

--- a/proto/agynio/api/groups/v1/events.proto
+++ b/proto/agynio/api/groups/v1/events.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+package agynio.api.groups.v1;
+
+import "agynio/api/groups/v1/groups.proto";
+
+option go_package = "github.com/agynio/api/gen/agynio/api/groups/v1;groupsv1";
+
+message GroupMembershipAddedEvent {
+  string group_id = 1;
+  GroupMemberType member_type = 2;
+  string member_id = 3;
+}
+
+message GroupMembershipRemovedEvent {
+  string group_id = 1;
+  GroupMemberType member_type = 2;
+  string member_id = 3;
+}
+
+message GroupDeletedEvent {
+  string group_id = 1;
+  string organization_id = 2;
+}

--- a/proto/agynio/api/groups/v1/groups.proto
+++ b/proto/agynio/api/groups/v1/groups.proto
@@ -1,0 +1,171 @@
+syntax = "proto3";
+
+package agynio.api.groups.v1;
+
+import "google/protobuf/timestamp.proto";
+
+option go_package = "github.com/agynio/api/gen/agynio/api/groups/v1;groupsv1";
+
+// GroupsService manages organization-scoped groups and memberships.
+service GroupsService {
+  // --- Groups ---
+  rpc CreateGroup(CreateGroupRequest) returns (CreateGroupResponse);
+  rpc GetGroup(GetGroupRequest) returns (GetGroupResponse);
+  rpc ListGroups(ListGroupsRequest) returns (ListGroupsResponse);
+  rpc UpdateGroup(UpdateGroupRequest) returns (UpdateGroupResponse);
+  rpc DeleteGroup(DeleteGroupRequest) returns (DeleteGroupResponse);
+
+  // --- Memberships ---
+  rpc AddMember(AddMemberRequest) returns (AddMemberResponse);
+  rpc RemoveMember(RemoveMemberRequest) returns (RemoveMemberResponse);
+  rpc ListMembers(ListMembersRequest) returns (ListMembersResponse);
+  rpc ListMemberGroups(ListMemberGroupsRequest) returns (ListMemberGroupsResponse);
+
+  // --- Internal ---
+  rpc ListMemberGroupsBatch(ListMemberGroupsBatchRequest) returns (ListMemberGroupsBatchResponse);
+}
+
+// Metadata shared by groups resources.
+message EntityMeta {
+  string id = 1;
+  google.protobuf.Timestamp created_at = 2;
+  google.protobuf.Timestamp updated_at = 3;
+}
+
+// Source of a group or group membership.
+enum GroupSource {
+  GROUP_SOURCE_UNSPECIFIED = 0;
+  GROUP_SOURCE_PLATFORM = 1;
+  GROUP_SOURCE_SCIM = 2;
+}
+
+// Identity types eligible for group membership.
+enum GroupMemberType {
+  GROUP_MEMBER_TYPE_UNSPECIFIED = 0;
+  GROUP_MEMBER_TYPE_USER = 1;
+  GROUP_MEMBER_TYPE_AGENT = 2;
+  GROUP_MEMBER_TYPE_APP = 3;
+}
+
+// Organization-scoped group.
+message Group {
+  EntityMeta meta = 1;
+  string organization_id = 2;
+  string name = 3;
+  string description = 4;
+  GroupSource source = 5;
+  optional string external_id = 6;
+}
+
+// Membership binding an identity to a group.
+message GroupMembership {
+  EntityMeta meta = 1;
+  string group_id = 2;
+  GroupMemberType member_type = 3;
+  string member_id = 4;
+  GroupSource source = 5;
+}
+
+message CreateGroupRequest {
+  string organization_id = 1;
+  string name = 2;
+  string description = 3;
+  GroupSource source = 4;
+  optional string external_id = 5;
+}
+
+message CreateGroupResponse {
+  Group group = 1;
+}
+
+message GetGroupRequest {
+  string id = 1;
+}
+
+message GetGroupResponse {
+  Group group = 1;
+}
+
+message ListGroupsRequest {
+  string organization_id = 1;
+  optional GroupSource source = 2;
+  int32 page_size = 3;
+  string page_token = 4;
+}
+
+message ListGroupsResponse {
+  repeated Group groups = 1;
+  string next_page_token = 2;
+}
+
+message UpdateGroupRequest {
+  string id = 1;
+  optional string name = 2;
+  optional string description = 3;
+}
+
+message UpdateGroupResponse {
+  Group group = 1;
+}
+
+message DeleteGroupRequest {
+  string id = 1;
+}
+
+message DeleteGroupResponse {}
+
+message AddMemberRequest {
+  string group_id = 1;
+  GroupMemberType member_type = 2;
+  string member_id = 3;
+  GroupSource source = 4;
+}
+
+message AddMemberResponse {
+  GroupMembership membership = 1;
+}
+
+message RemoveMemberRequest {
+  string group_id = 1;
+  string member_id = 2;
+}
+
+message RemoveMemberResponse {}
+
+message ListMembersRequest {
+  string group_id = 1;
+  optional GroupMemberType member_type = 2;
+  int32 page_size = 3;
+  string page_token = 4;
+}
+
+message ListMembersResponse {
+  repeated GroupMembership memberships = 1;
+  string next_page_token = 2;
+}
+
+message ListMemberGroupsRequest {
+  GroupMemberType member_type = 1;
+  string member_id = 2;
+  int32 page_size = 3;
+  string page_token = 4;
+}
+
+message ListMemberGroupsResponse {
+  repeated Group groups = 1;
+  string next_page_token = 2;
+}
+
+message ListMemberGroupsBatchRequest {
+  repeated ListMemberGroupsRequest members = 1;
+}
+
+message ListMemberGroupsBatchEntry {
+  GroupMemberType member_type = 1;
+  string member_id = 2;
+  repeated Group groups = 3;
+}
+
+message ListMemberGroupsBatchResponse {
+  repeated ListMemberGroupsBatchEntry entries = 1;
+}

--- a/proto/agynio/api/networks/v1/events.proto
+++ b/proto/agynio/api/networks/v1/events.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+
+package agynio.api.networks.v1;
+
+import "agynio/api/networks/v1/networks.proto";
+
+option go_package = "github.com/agynio/api/gen/agynio/api/networks/v1;networksv1";
+
+message TunnelOnlineEvent {
+  string tunnel_credential_id = 1;
+  string network_id = 2;
+}
+
+message TunnelOfflineEvent {
+  string tunnel_credential_id = 1;
+  string network_id = 2;
+}
+
+message PrivateResourceAccessGrantedEvent {
+  string private_resource_access_id = 1;
+  string private_resource_id = 2;
+  PrivateResourceAccessPrincipalType principal_type = 3;
+  string principal_id = 4;
+}
+
+message PrivateResourceAccessRevokedEvent {
+  string private_resource_access_id = 1;
+  string private_resource_id = 2;
+  PrivateResourceAccessPrincipalType principal_type = 3;
+  string principal_id = 4;
+}

--- a/proto/agynio/api/networks/v1/networks.proto
+++ b/proto/agynio/api/networks/v1/networks.proto
@@ -1,0 +1,296 @@
+syntax = "proto3";
+
+package agynio.api.networks.v1;
+
+import "google/protobuf/timestamp.proto";
+
+option go_package = "github.com/agynio/api/gen/agynio/api/networks/v1;networksv1";
+
+// NetworksService manages private networks, tunnels, resources, and grants.
+service NetworksService {
+  // --- Networks ---
+  rpc CreateNetwork(CreateNetworkRequest) returns (CreateNetworkResponse);
+  rpc GetNetwork(GetNetworkRequest) returns (GetNetworkResponse);
+  rpc ListNetworks(ListNetworksRequest) returns (ListNetworksResponse);
+  rpc UpdateNetwork(UpdateNetworkRequest) returns (UpdateNetworkResponse);
+  rpc DeleteNetwork(DeleteNetworkRequest) returns (DeleteNetworkResponse);
+
+  // --- Tunnel Credentials ---
+  rpc CreateTunnelCredential(CreateTunnelCredentialRequest) returns (CreateTunnelCredentialResponse);
+  rpc GetTunnelCredential(GetTunnelCredentialRequest) returns (GetTunnelCredentialResponse);
+  rpc ListTunnelCredentials(ListTunnelCredentialsRequest) returns (ListTunnelCredentialsResponse);
+  rpc DeleteTunnelCredential(DeleteTunnelCredentialRequest) returns (DeleteTunnelCredentialResponse);
+
+  // --- Private Resources ---
+  rpc CreatePrivateResource(CreatePrivateResourceRequest) returns (CreatePrivateResourceResponse);
+  rpc GetPrivateResource(GetPrivateResourceRequest) returns (GetPrivateResourceResponse);
+  rpc ListPrivateResources(ListPrivateResourcesRequest) returns (ListPrivateResourcesResponse);
+  rpc UpdatePrivateResource(UpdatePrivateResourceRequest) returns (UpdatePrivateResourceResponse);
+  rpc DeletePrivateResource(DeletePrivateResourceRequest) returns (DeletePrivateResourceResponse);
+
+  // --- Private Resource Access ---
+  rpc CreatePrivateResourceAccess(CreatePrivateResourceAccessRequest) returns (CreatePrivateResourceAccessResponse);
+  rpc DeletePrivateResourceAccess(DeletePrivateResourceAccessRequest) returns (DeletePrivateResourceAccessResponse);
+  rpc ListPrivateResourceAccess(ListPrivateResourceAccessRequest) returns (ListPrivateResourceAccessResponse);
+}
+
+// Metadata shared by network resources.
+message EntityMeta {
+  string id = 1;
+  google.protobuf.Timestamp created_at = 2;
+  google.protobuf.Timestamp updated_at = 3;
+}
+
+// Provisioning state for OpenZiti-backed resources.
+enum ProvisioningState {
+  PROVISIONING_STATE_UNSPECIFIED = 0;
+  PROVISIONING_STATE_ACTIVE = 1;
+  PROVISIONING_STATE_FAILED = 2;
+  PROVISIONING_STATE_REMOVING = 3;
+}
+
+// Tunnel enrollment state from the OpenZiti Controller.
+enum TunnelEnrollmentState {
+  TUNNEL_ENROLLMENT_STATE_UNSPECIFIED = 0;
+  TUNNEL_ENROLLMENT_STATE_PENDING = 1;
+  TUNNEL_ENROLLMENT_STATE_ENROLLED = 2;
+}
+
+// Tunnel connectivity state from the OpenZiti Controller.
+enum TunnelConnectivity {
+  TUNNEL_CONNECTIVITY_UNSPECIFIED = 0;
+  TUNNEL_CONNECTIVITY_ONLINE = 1;
+  TUNNEL_CONNECTIVITY_OFFLINE = 2;
+}
+
+// Protocol for a private resource. UDP is not supported in v1.
+enum PrivateResourceProtocol {
+  PRIVATE_RESOURCE_PROTOCOL_UNSPECIFIED = 0;
+  PRIVATE_RESOURCE_PROTOCOL_TCP = 1;
+  PRIVATE_RESOURCE_PROTOCOL_HTTP = 2;
+  PRIVATE_RESOURCE_PROTOCOL_HTTPS = 3;
+}
+
+// Principal types eligible for private resource access.
+enum PrivateResourceAccessPrincipalType {
+  PRIVATE_RESOURCE_ACCESS_PRINCIPAL_TYPE_UNSPECIFIED = 0;
+  PRIVATE_RESOURCE_ACCESS_PRINCIPAL_TYPE_AGENT = 1;
+  PRIVATE_RESOURCE_ACCESS_PRINCIPAL_TYPE_USER = 2;
+  PRIVATE_RESOURCE_ACCESS_PRINCIPAL_TYPE_APP = 3;
+  PRIVATE_RESOURCE_ACCESS_PRINCIPAL_TYPE_GROUP = 4;
+}
+
+// Organization-scoped private network.
+message Network {
+  EntityMeta meta = 1;
+  string organization_id = 2;
+  string name = 3;
+  string description = 4;
+  ProvisioningState provisioning_state = 5;
+}
+
+// Read-side tunnel credential. The one-time enrollment JWT is only returned by
+// CreateTunnelCredentialResponse and is intentionally absent from this message.
+message TunnelCredential {
+  EntityMeta meta = 1;
+  string network_id = 2;
+  bool enrollment_jwt_revealed = 3;
+  google.protobuf.Timestamp enrollment_jwt_expires_at = 4;
+  TunnelEnrollmentState enrollment_state = 5;
+  TunnelConnectivity connectivity = 6;
+  ProvisioningState provisioning_state = 7;
+  optional google.protobuf.Timestamp enrolled_at = 8;
+  optional google.protobuf.Timestamp last_seen_at = 9;
+}
+
+// Addressable endpoint behind a private network.
+message PrivateResource {
+  EntityMeta meta = 1;
+  string organization_id = 2;
+  string network_id = 3;
+  string name = 4;
+  PrivateResourceProtocol protocol = 5;
+  string target_host = 6;
+  // Numeric target ports. Each value must be in the range 1..65535.
+  repeated int32 target_ports = 7;
+  string intercept_host = 8;
+  // Numeric intercept ports. Each value must be in the range 1..65535.
+  repeated int32 intercept_ports = 9;
+  ProvisioningState provisioning_state = 10;
+}
+
+// Immutable grant authorizing a principal to dial a private resource.
+message PrivateResourceAccess {
+  EntityMeta meta = 1;
+  string private_resource_id = 2;
+  PrivateResourceAccessPrincipalType principal_type = 3;
+  string principal_id = 4;
+}
+
+message CreateNetworkRequest {
+  string organization_id = 1;
+  string name = 2;
+  string description = 3;
+}
+
+message CreateNetworkResponse {
+  Network network = 1;
+}
+
+message GetNetworkRequest {
+  string id = 1;
+}
+
+message GetNetworkResponse {
+  Network network = 1;
+}
+
+message ListNetworksRequest {
+  string organization_id = 1;
+  int32 page_size = 2;
+  string page_token = 3;
+}
+
+message ListNetworksResponse {
+  repeated Network networks = 1;
+  string next_page_token = 2;
+}
+
+message UpdateNetworkRequest {
+  string id = 1;
+  optional string name = 2;
+  optional string description = 3;
+}
+
+message UpdateNetworkResponse {
+  Network network = 1;
+}
+
+message DeleteNetworkRequest {
+  string id = 1;
+}
+
+message DeleteNetworkResponse {}
+
+message CreateTunnelCredentialRequest {
+  string network_id = 1;
+}
+
+message CreateTunnelCredentialResponse {
+  TunnelCredential tunnel_credential = 1;
+  // One-time enrollment JWT. It is not returned by read/list responses.
+  string enrollment_jwt = 2;
+}
+
+message GetTunnelCredentialRequest {
+  string id = 1;
+}
+
+message GetTunnelCredentialResponse {
+  TunnelCredential tunnel_credential = 1;
+}
+
+message ListTunnelCredentialsRequest {
+  string network_id = 1;
+  int32 page_size = 2;
+  string page_token = 3;
+}
+
+message ListTunnelCredentialsResponse {
+  repeated TunnelCredential tunnel_credentials = 1;
+  string next_page_token = 2;
+}
+
+message DeleteTunnelCredentialRequest {
+  string id = 1;
+}
+
+message DeleteTunnelCredentialResponse {}
+
+message CreatePrivateResourceRequest {
+  string network_id = 1;
+  string name = 2;
+  PrivateResourceProtocol protocol = 3;
+  string target_host = 4;
+  // Numeric target ports. Each value must be in the range 1..65535.
+  repeated int32 target_ports = 5;
+  string intercept_host = 6;
+  // Numeric intercept ports. Each value must be in the range 1..65535.
+  repeated int32 intercept_ports = 7;
+}
+
+message CreatePrivateResourceResponse {
+  PrivateResource private_resource = 1;
+}
+
+message GetPrivateResourceRequest {
+  string id = 1;
+}
+
+message GetPrivateResourceResponse {
+  PrivateResource private_resource = 1;
+}
+
+message ListPrivateResourcesRequest {
+  optional string organization_id = 1;
+  optional string network_id = 2;
+  int32 page_size = 3;
+  string page_token = 4;
+}
+
+message ListPrivateResourcesResponse {
+  repeated PrivateResource private_resources = 1;
+  string next_page_token = 2;
+}
+
+message UpdatePrivateResourceRequest {
+  string id = 1;
+  optional string name = 2;
+  optional PrivateResourceProtocol protocol = 3;
+  optional string target_host = 4;
+  // Numeric target ports. Each value must be in the range 1..65535.
+  repeated int32 target_ports = 5;
+  optional string intercept_host = 6;
+  // Numeric intercept ports. Each value must be in the range 1..65535.
+  repeated int32 intercept_ports = 7;
+}
+
+message UpdatePrivateResourceResponse {
+  PrivateResource private_resource = 1;
+}
+
+message DeletePrivateResourceRequest {
+  string id = 1;
+}
+
+message DeletePrivateResourceResponse {}
+
+message CreatePrivateResourceAccessRequest {
+  string private_resource_id = 1;
+  PrivateResourceAccessPrincipalType principal_type = 2;
+  string principal_id = 3;
+}
+
+message CreatePrivateResourceAccessResponse {
+  PrivateResourceAccess private_resource_access = 1;
+}
+
+message DeletePrivateResourceAccessRequest {
+  string id = 1;
+}
+
+message DeletePrivateResourceAccessResponse {}
+
+message ListPrivateResourceAccessRequest {
+  optional string private_resource_id = 1;
+  optional string network_id = 2;
+  optional PrivateResourceAccessPrincipalType principal_type = 3;
+  optional string principal_id = 4;
+  int32 page_size = 5;
+  string page_token = 6;
+}
+
+message ListPrivateResourceAccessResponse {
+  repeated PrivateResourceAccess private_resource_access = 1;
+  string next_page_token = 2;
+}

--- a/proto/agynio/api/ziti_management/v1/ziti_management.proto
+++ b/proto/agynio/api/ziti_management/v1/ziti_management.proto
@@ -66,6 +66,30 @@ service ZitiManagementService {
 
   // Users Service -> delete a device's OpenZiti identity.
   rpc DeleteDeviceIdentity(DeleteDeviceIdentityRequest) returns (DeleteDeviceIdentityResponse);
+
+  // Networks Service -> create an OpenZiti identity for a private-network tunnel.
+  rpc CreateTunnelIdentity(CreateTunnelIdentityRequest) returns (CreateTunnelIdentityResponse);
+
+  // Networks Service -> delete a tunnel's OpenZiti identity.
+  rpc DeleteTunnelIdentity(DeleteTunnelIdentityRequest) returns (DeleteTunnelIdentityResponse);
+
+  // Users Service, Apps Service, Agents Orchestrator -> add and remove role attributes.
+  rpc PatchIdentityRoleAttributes(PatchIdentityRoleAttributesRequest) returns (PatchIdentityRoleAttributesResponse);
+
+  // Networks Service -> fetch identity enrollment and connectivity state.
+  rpc GetIdentityLiveness(GetIdentityLivenessRequest) returns (GetIdentityLivenessResponse);
+
+  // Services managing OpenZiti resources -> list services matching tag filters.
+  rpc ListServicesByTag(ListServicesByTagRequest) returns (ListServicesByTagResponse);
+
+  // Networks Service -> list identities matching tag filters.
+  rpc ListIdentitiesByTag(ListIdentitiesByTagRequest) returns (ListIdentitiesByTagResponse);
+
+  // Services managing OpenZiti resources -> list service policies matching tag filters.
+  rpc ListServicePoliciesByTag(ListServicePoliciesByTagRequest) returns (ListServicePoliciesByTagResponse);
+
+  // Networks Service -> update an existing OpenZiti service's attached configs.
+  rpc UpdateService(UpdateServiceRequest) returns (UpdateServiceResponse);
 }
 
 enum ServiceType {
@@ -98,6 +122,10 @@ message ManagedIdentity {
 message CreateAgentIdentityRequest {
   string agent_id = 1;
   string workload_id = 2;
+  // Extra role attributes such as group-<id>. Base agent attributes are added by Ziti Management.
+  repeated string additional_role_attributes = 3;
+  // Tags attached to the OpenZiti identity.
+  map<string, string> tags = 4;
 }
 
 message CreateAgentIdentityResponse {
@@ -109,6 +137,10 @@ message CreateAgentIdentityResponse {
 message CreateAppIdentityRequest {
   string identity_id = 1;
   string slug = 2;
+  // Extra role attributes such as group-<id>. Base app attributes are added by Ziti Management.
+  repeated string additional_role_attributes = 3;
+  // Tags attached to the OpenZiti identity.
+  map<string, string> tags = 4;
 }
 
 // Response with enrolled OpenZiti credentials for an app identity.
@@ -156,6 +188,8 @@ message CreateServiceRequest {
   // Optional intercept.v1 config to create and attach to the service.
   // Used by Expose Service for port exposure.
   optional InterceptV1Config intercept_v1_config = 4;
+  // Tags attached to the OpenZiti service and any created config resources.
+  map<string, string> tags = 5;
 }
 
 message CreateServiceResponse {
@@ -179,6 +213,8 @@ message DeleteAppIdentityResponse {}
 message CreateRunnerIdentityRequest {
   string runner_id = 1;
   repeated string role_attributes = 2;
+  // Tags attached to the OpenZiti identity.
+  map<string, string> tags = 5;
 }
 
 message CreateRunnerIdentityResponse {
@@ -259,6 +295,8 @@ message CreateServicePolicyRequest {
   repeated string identity_roles = 3;
   // Service roles for the policy (e.g. ["@exposed-<id>"]).
   repeated string service_roles = 4;
+  // Tags attached to the OpenZiti service policy.
+  map<string, string> tags = 5;
 }
 
 message CreateServicePolicyResponse {
@@ -297,6 +335,10 @@ message CreateDeviceIdentityRequest {
   string user_identity_id = 1;
   // User-provided device name.
   string name = 2;
+  // Extra role attributes such as group-<id>. Base device/user attributes are added by Ziti Management.
+  repeated string additional_role_attributes = 3;
+  // Tags attached to the OpenZiti identity.
+  map<string, string> tags = 4;
 }
 
 message CreateDeviceIdentityResponse {
@@ -316,3 +358,143 @@ message DeleteDeviceIdentityRequest {
 }
 
 message DeleteDeviceIdentityResponse {}
+
+// ===========================================================================
+// CreateTunnelIdentity
+// ===========================================================================
+
+message CreateTunnelIdentityRequest {
+  string network_id = 1;
+  string tunnel_credential_id = 2;
+  map<string, string> tags = 3;
+}
+
+message CreateTunnelIdentityResponse {
+  string ziti_identity_id = 1;
+  string enrollment_jwt = 2;
+  google.protobuf.Timestamp enrollment_jwt_expires_at = 3;
+}
+
+// ===========================================================================
+// DeleteTunnelIdentity
+// ===========================================================================
+
+message DeleteTunnelIdentityRequest {
+  string ziti_identity_id = 1;
+}
+
+message DeleteTunnelIdentityResponse {}
+
+// ===========================================================================
+// PatchIdentityRoleAttributes
+// ===========================================================================
+
+message PatchIdentityRoleAttributesRequest {
+  string ziti_identity_id = 1;
+  repeated string add = 2;
+  repeated string remove = 3;
+}
+
+message PatchIdentityRoleAttributesResponse {}
+
+// ===========================================================================
+// GetIdentityLiveness
+// ===========================================================================
+
+enum IdentityEnrollmentState {
+  IDENTITY_ENROLLMENT_STATE_UNSPECIFIED = 0;
+  IDENTITY_ENROLLMENT_STATE_PENDING = 1;
+  IDENTITY_ENROLLMENT_STATE_ENROLLED = 2;
+}
+
+message GetIdentityLivenessRequest {
+  string ziti_identity_id = 1;
+}
+
+message GetIdentityLivenessResponse {
+  IdentityEnrollmentState enrollment_state = 1;
+  bool has_edge_router_connection = 2;
+}
+
+// ===========================================================================
+// ListServicesByTag
+// ===========================================================================
+
+message OpenZitiService {
+  string ziti_service_id = 1;
+  string name = 2;
+  repeated string role_attributes = 3;
+  map<string, string> tags = 4;
+}
+
+message ListServicesByTagRequest {
+  map<string, string> tags = 1;
+  int32 page_size = 2;
+  string page_token = 3;
+}
+
+message ListServicesByTagResponse {
+  repeated OpenZitiService services = 1;
+  string next_page_token = 2;
+}
+
+// ===========================================================================
+// ListIdentitiesByTag
+// ===========================================================================
+
+message OpenZitiIdentity {
+  string ziti_identity_id = 1;
+  string name = 2;
+  repeated string role_attributes = 3;
+  map<string, string> tags = 4;
+}
+
+message ListIdentitiesByTagRequest {
+  map<string, string> tags = 1;
+  int32 page_size = 2;
+  string page_token = 3;
+}
+
+message ListIdentitiesByTagResponse {
+  repeated OpenZitiIdentity identities = 1;
+  string next_page_token = 2;
+}
+
+// ===========================================================================
+// ListServicePoliciesByTag
+// ===========================================================================
+
+message OpenZitiServicePolicy {
+  string ziti_service_policy_id = 1;
+  string name = 2;
+  ServicePolicyType type = 3;
+  repeated string identity_roles = 4;
+  repeated string service_roles = 5;
+  map<string, string> tags = 6;
+}
+
+message ListServicePoliciesByTagRequest {
+  map<string, string> tags = 1;
+  int32 page_size = 2;
+  string page_token = 3;
+}
+
+message ListServicePoliciesByTagResponse {
+  repeated OpenZitiServicePolicy service_policies = 1;
+  string next_page_token = 2;
+}
+
+// ===========================================================================
+// UpdateService
+// ===========================================================================
+
+message UpdateServiceRequest {
+  string ziti_service_id = 1;
+  optional HostV1Config host_v1_config = 2;
+  optional InterceptV1Config intercept_v1_config = 3;
+  map<string, string> tags = 4;
+}
+
+message UpdateServiceResponse {
+  OpenZitiService service = 1;
+}


### PR DESCRIPTION
## Summary

- Add Groups service, Gateway, and durable event protobuf contracts.
- Add Networks service, Gateway, and durable event protobuf contracts.
- Extend Ziti Management contracts with Private Networks and group role-attribute sync RPCs and backwards-compatible fields.

Closes #149

## Out of scope

No service implementation, Gateway handlers, DB migrations, NATS deployment, OpenFGA changes, or generated downstream client updates are included.

## Test & Lint Summary

- `buf lint` — passed with no errors.
- `buf breaking --against '.git#branch=origin/main'` — passed with no breaking changes.
- `git diff --check` — passed with no whitespace errors.

Test statistics: 3 passed / 0 failed / 0 skipped.
Linting passed with no errors.