### PR TITLE
fix(api): address private network contract review

### DIFF
--- a/proto/agynio/api/groups/v1/groups.proto
+++ b/proto/agynio/api/groups/v1/groups.proto
@@ -149,6 +149,7 @@ message ListMemberGroupsRequest {
   string member_id = 2;
   int32 page_size = 3;
   string page_token = 4;
+  string organization_id = 5;
 }
 
 message ListMemberGroupsResponse {

--- a/proto/agynio/api/networks/v1/networks.proto
+++ b/proto/agynio/api/networks/v1/networks.proto
@@ -125,6 +125,13 @@ message PrivateResourceAccess {
   string private_resource_id = 2;
   PrivateResourceAccessPrincipalType principal_type = 3;
   string principal_id = 4;
+  ProvisioningState provisioning_state = 5;
+}
+
+// Optional replacement for a port list in update requests.
+message PortListUpdate {
+  // Numeric ports. Each value must be in the range 1..65535.
+  repeated int32 ports = 1;
 }
 
 message CreateNetworkRequest {
@@ -248,11 +255,13 @@ message UpdatePrivateResourceRequest {
   optional string name = 2;
   optional PrivateResourceProtocol protocol = 3;
   optional string target_host = 4;
-  // Numeric target ports. Each value must be in the range 1..65535.
-  repeated int32 target_ports = 5;
+  // Deprecated: use target_ports_update to distinguish omitted from empty.
+  repeated int32 target_ports = 5 [deprecated = true];
   optional string intercept_host = 6;
-  // Numeric intercept ports. Each value must be in the range 1..65535.
-  repeated int32 intercept_ports = 7;
+  // Deprecated: use intercept_ports_update to distinguish omitted from empty.
+  repeated int32 intercept_ports = 7 [deprecated = true];
+  optional PortListUpdate target_ports_update = 8;
+  optional PortListUpdate intercept_ports_update = 9;
 }
 
 message UpdatePrivateResourceResponse {

--- a/proto/agynio/api/ziti_management/v1/ziti_management.proto
+++ b/proto/agynio/api/ziti_management/v1/ziti_management.proto
@@ -214,6 +214,8 @@ message CreateRunnerIdentityRequest {
   string runner_id = 1;
   repeated string role_attributes = 2;
   // Tags attached to the OpenZiti identity.
+  reserved 3, 4;
+  reserved "ziti_service_id", "ziti_service_name";
   map<string, string> tags = 5;
 }
 
@@ -492,7 +494,13 @@ message UpdateServiceRequest {
   string ziti_service_id = 1;
   optional HostV1Config host_v1_config = 2;
   optional InterceptV1Config intercept_v1_config = 3;
-  map<string, string> tags = 4;
+  // Deprecated: use tags_update to distinguish omitted from empty.
+  map<string, string> tags = 4 [deprecated = true];
+  optional TagsUpdate tags_update = 5;
+}
+
+message TagsUpdate {
+  map<string, string> tags = 1;
 }
 
 message UpdateServiceResponse {


### PR DESCRIPTION
## Summary

- Add organization scoping to `ListMemberGroupsRequest`.
- Add `provisioning_state` to `PrivateResourceAccess`.
- Add presence-aware update wrappers for private resource ports and Ziti service tags while preserving existing fields as deprecated for compatibility.
- Reserve the documented `CreateRunnerIdentityRequest` field-number gap.

Closes #151

## Out of scope

Contract-only follow-up. No service implementation, Gateway handlers, DB migrations, NATS deployment, OpenFGA changes, or downstream generated client updates are included.

## Test & Lint Summary

- `buf lint` — passed with no errors.
- `buf breaking --against '.git#branch=origin/main'` — passed with no breaking changes.
- `git diff --check` — passed with no whitespace errors.

Test statistics: 3 passed / 0 failed / 0 skipped.
Linting passed with no errors.