### PR TITLE
feat(identity): add agent instance handles

### DIFF
--- a/proto/agynio/api/identity/v1/identity.proto
+++ b/proto/agynio/api/identity/v1/identity.proto
@@ -15,12 +15,12 @@ service IdentityService {
   // BatchGetIdentityTypes returns known identity types for the requested IDs.
   // Unknown identity IDs are omitted from the response.
   rpc BatchGetIdentityTypes(BatchGetIdentityTypesRequest) returns (BatchGetIdentityTypesResponse);
-  // SetNickname sets or updates the nickname for an identity within an org.
-  // Returns ALREADY_EXISTS if the nickname is already taken in the org.
+  // SetNickname sets or updates the nickname handle for an identity within an org.
+  // Returns ALREADY_EXISTS if the full handle is already taken in the org.
   rpc SetNickname(SetNicknameRequest) returns (SetNicknameResponse);
   // RemoveNickname deletes the nickname entry for an identity within an org.
   rpc RemoveNickname(RemoveNicknameRequest) returns (RemoveNicknameResponse);
-  // ResolveNickname resolves an @nickname within an org to its identity.
+  // ResolveNickname resolves an @nickname or @nickname#instance_suffix within an org to its identity.
   rpc ResolveNickname(ResolveNicknameRequest) returns (ResolveNicknameResponse);
   // BatchGetNicknames resolves identity IDs to nicknames within an org.
   // Unknown or unset nicknames are omitted from the response.
@@ -33,6 +33,7 @@ enum IdentityType {
   IDENTITY_TYPE_RUNNER = 2;
   IDENTITY_TYPE_USER = 4;
   IDENTITY_TYPE_APP = 5;
+  IDENTITY_TYPE_AGENT_INSTANCE = 6;
   reserved 3;
   reserved "IDENTITY_TYPE_CHANNEL";
 }
@@ -68,9 +69,13 @@ message BatchGetIdentityTypesResponse {
 message SetNicknameRequest {
   string organization_id = 1;
   string identity_id = 2;
+  // Handle stem without leading @. Pattern: ^[a-z0-9_-]+$, max 32 chars.
   string nickname = 3;
   // Optional app installation ID; required for app installation nicknames.
   optional string installation_id = 4;
+  // Optional agent instance handle suffix without leading #. Set only for agent_instance identities.
+  // Pattern: ^[a-z0-9_-]+$, max 32 chars.
+  optional string instance_suffix = 5;
 }
 
 message SetNicknameResponse {}
@@ -86,13 +91,18 @@ message RemoveNicknameResponse {}
 
 message ResolveNicknameRequest {
   string organization_id = 1;
+  // Handle stem, optionally prefixed with @. May include #instance_suffix.
   string nickname = 2;
+  // Optional agent instance handle suffix without leading #. When set, nickname must not include #.
+  optional string instance_suffix = 3;
 }
 
 message ResolveNicknameResponse {
   string identity_id = 1;
   IdentityType identity_type = 2;
   optional string installation_id = 3;
+  // Agent instance handle suffix when identity_type is IDENTITY_TYPE_AGENT_INSTANCE.
+  optional string instance_suffix = 4;
 }
 
 message BatchGetNicknamesRequest {
@@ -102,7 +112,10 @@ message BatchGetNicknamesRequest {
 
 message NicknameEntry {
   string identity_id = 1;
+  // Handle stem without leading @.
   string nickname = 2;
+  // Agent instance handle suffix without leading #.
+  optional string instance_suffix = 3;
 }
 
 message BatchGetNicknamesResponse {


### PR DESCRIPTION
## Summary

- Add `IDENTITY_TYPE_AGENT_INSTANCE` to the Identity API contract.
- Add `instance_suffix` to nickname write, resolve, and batch-read contracts for `@class#suffix` handles.
- Document handle stem/suffix expectations for agent instance nicknames.

Notes:
- Kept enum value `3` reserved for compatibility with the previous `IDENTITY_TYPE_CHANNEL` reservation; `agent_instance` uses value `6` to satisfy Buf breaking checks.
- Scope is API contracts only for Phase 1A of #161.

## Test & Lint Summary

Commands run:

```bash
buf lint
buf breaking --against '.git#branch=main'
```

Results:

- Tests: not applicable for proto-only API contract change.
- Lint: `buf lint` passed with no errors.
- Breaking validation: `buf breaking --against '.git#branch=main'` passed with no errors.

Closes part of #161.