### PR TITLE
feat(api): add sandbox contracts

### DIFF
--- a/proto/agynio/api/agents/v1/agents.proto
+++ b/proto/agynio/api/agents/v1/agents.proto
@@ -539,7 +539,6 @@ message CreateSandboxRequest {
   string organization_id = 1;
   optional string name = 2;
   string environment_id = 3;
-  string owner_id = 4;
 }
 
 message CreateSandboxResponse {
@@ -738,6 +737,7 @@ message ImagePullSecretAttachment {
     string agent_id = 3;
     string mcp_id = 4;
     string hook_id = 5;
+    string environment_id = 6;
   }
 }
 
@@ -747,6 +747,7 @@ message CreateImagePullSecretAttachmentRequest {
     string agent_id = 2;
     string mcp_id = 3;
     string hook_id = 4;
+    string environment_id = 5;
   }
 }
 
@@ -775,6 +776,7 @@ message ListImagePullSecretAttachmentsRequest {
   string agent_id = 4;
   string mcp_id = 5;
   string hook_id = 6;
+  string environment_id = 7;
 }
 
 message ListImagePullSecretAttachmentsResponse {
@@ -982,6 +984,7 @@ message Env {
     string agent_id = 4;
     string mcp_id = 5;
     string hook_id = 6;
+    string environment_id = 9;
   }
   oneof source {
     string value = 7;
@@ -996,6 +999,7 @@ message CreateEnvRequest {
     string agent_id = 3;
     string mcp_id = 4;
     string hook_id = 5;
+    string environment_id = 8;
   }
   oneof source {
     string value = 6;
@@ -1039,6 +1043,7 @@ message ListEnvsRequest {
   string agent_id = 3;
   string mcp_id = 4;
   string hook_id = 5;
+  string environment_id = 6;
 }
 
 message ListEnvsResponse {

--- a/proto/agynio/api/agents/v1/agents.proto
+++ b/proto/agynio/api/agents/v1/agents.proto
@@ -25,6 +25,22 @@ service AgentsService {
   rpc ListAgentRoles(ListAgentRolesRequest) returns (ListAgentRolesResponse);
   rpc ListMyAgentRoles(ListMyAgentRolesRequest) returns (ListMyAgentRolesResponse);
 
+  // --- Environments ---
+  rpc CreateEnvironment(CreateEnvironmentRequest) returns (CreateEnvironmentResponse);
+  rpc GetEnvironment(GetEnvironmentRequest) returns (GetEnvironmentResponse);
+  rpc UpdateEnvironment(UpdateEnvironmentRequest) returns (UpdateEnvironmentResponse);
+  rpc DeleteEnvironment(DeleteEnvironmentRequest) returns (DeleteEnvironmentResponse);
+  rpc ListEnvironments(ListEnvironmentsRequest) returns (ListEnvironmentsResponse);
+
+  // --- Sandboxes ---
+  rpc CreateSandbox(CreateSandboxRequest) returns (CreateSandboxResponse);
+  rpc GetSandbox(GetSandboxRequest) returns (GetSandboxResponse);
+  rpc ListSandboxes(ListSandboxesRequest) returns (ListSandboxesResponse);
+  rpc StopSandbox(StopSandboxRequest) returns (StopSandboxResponse);
+  rpc DeleteSandbox(DeleteSandboxRequest) returns (DeleteSandboxResponse);
+  rpc EnsureSandboxRunning(EnsureSandboxRunningRequest) returns (EnsureSandboxRunningResponse);
+  rpc UpdateSandboxLastSession(UpdateSandboxLastSessionRequest) returns (UpdateSandboxLastSessionResponse);
+
   // --- Agent Instances ---
   rpc CreateInstance(CreateInstanceRequest) returns (CreateInstanceResponse);
   rpc GetInstance(GetInstanceRequest) returns (GetInstanceResponse);
@@ -430,6 +446,166 @@ message GetUnackedInboxCountRequest {
 
 message GetUnackedInboxCountResponse {
   int32 count = 1;
+}
+
+// ===========================================================================
+// Environment
+// ===========================================================================
+
+message Environment {
+  EntityMeta meta = 1;
+  string organization_id = 2;
+  string name = 3;
+  string flavor_id = 4;
+  string image = 5;
+  string flavor_name = 6;
+}
+
+message CreateEnvironmentRequest {
+  string organization_id = 1;
+  string name = 2;
+  string flavor_id = 3;
+  string image = 4;
+}
+
+message CreateEnvironmentResponse {
+  Environment environment = 1;
+}
+
+message GetEnvironmentRequest {
+  string id = 1; // UUID
+}
+
+message GetEnvironmentResponse {
+  Environment environment = 1;
+}
+
+message UpdateEnvironmentRequest {
+  string id = 1; // UUID
+  optional string name = 2;
+  optional string flavor_id = 3;
+  optional string image = 4;
+}
+
+message UpdateEnvironmentResponse {
+  Environment environment = 1;
+}
+
+message DeleteEnvironmentRequest {
+  string id = 1; // UUID
+}
+
+message DeleteEnvironmentResponse {}
+
+message ListEnvironmentsRequest {
+  int32 page_size = 1;
+  string page_token = 2;
+  string organization_id = 3;
+}
+
+message ListEnvironmentsResponse {
+  repeated Environment environments = 1;
+  string next_page_token = 2;
+}
+
+// ===========================================================================
+// Sandbox
+// ===========================================================================
+
+enum SandboxStatus {
+  SANDBOX_STATUS_UNSPECIFIED = 0;
+  SANDBOX_STATUS_STARTING = 1;
+  SANDBOX_STATUS_RUNNING = 2;
+  SANDBOX_STATUS_STOPPED = 3;
+  SANDBOX_STATUS_FAILED = 4;
+  SANDBOX_STATUS_TERMINATED = 5;
+}
+
+message Sandbox {
+  EntityMeta meta = 1;
+  string organization_id = 2;
+  string name = 3;
+  string environment_id = 4;
+  string owner_id = 5;
+  SandboxStatus status = 6;
+  string idle_timeout = 7;
+  string ttl = 8;
+  optional google.protobuf.Timestamp last_session_at = 9;
+  string environment_name = 10;
+  optional string workload_id = 11;
+}
+
+message CreateSandboxRequest {
+  string organization_id = 1;
+  optional string name = 2;
+  string environment_id = 3;
+  string owner_id = 4;
+}
+
+message CreateSandboxResponse {
+  Sandbox sandbox = 1;
+}
+
+message GetSandboxRequest {
+  oneof ref {
+    string id = 1;
+    SandboxNameRef name = 2;
+  }
+}
+
+message SandboxNameRef {
+  string organization_id = 1;
+  string name = 2;
+}
+
+message GetSandboxResponse {
+  Sandbox sandbox = 1;
+}
+
+message ListSandboxesRequest {
+  int32 page_size = 1;
+  string page_token = 2;
+  string organization_id = 3;
+  optional string owner_id = 4;
+  bool include_terminated = 5;
+}
+
+message ListSandboxesResponse {
+  repeated Sandbox sandboxes = 1;
+  string next_page_token = 2;
+}
+
+message StopSandboxRequest {
+  string id = 1;
+}
+
+message StopSandboxResponse {
+  Sandbox sandbox = 1;
+}
+
+message DeleteSandboxRequest {
+  string id = 1;
+}
+
+message DeleteSandboxResponse {
+  Sandbox sandbox = 1;
+}
+
+message EnsureSandboxRunningRequest {
+  string id = 1;
+}
+
+message EnsureSandboxRunningResponse {
+  Sandbox sandbox = 1;
+}
+
+message UpdateSandboxLastSessionRequest {
+  string id = 1;
+  google.protobuf.Timestamp last_session_at = 2;
+}
+
+message UpdateSandboxLastSessionResponse {
+  Sandbox sandbox = 1;
 }
 
 // ===========================================================================

--- a/proto/agynio/api/egress/v1/egress.proto
+++ b/proto/agynio/api/egress/v1/egress.proto
@@ -6,7 +6,7 @@ import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/agynio/api/gen/agynio/api/egress/v1;egressv1";
 
-// EgressRulesService manages egress rules and agent attachments.
+// EgressRulesService manages egress rules and workload-source attachments.
 service EgressRulesService {
   // --- Egress Rules ---
   rpc CreateEgressRule(CreateEgressRuleRequest) returns (CreateEgressRuleResponse);
@@ -22,6 +22,7 @@ service EgressRulesService {
 
   // --- Internal ---
   rpc ListEgressRulesByAgent(ListEgressRulesByAgentRequest) returns (ListEgressRulesByAgentResponse);
+  rpc ListEgressRulesByEnvironment(ListEgressRulesByEnvironmentRequest) returns (ListEgressRulesByEnvironmentResponse);
   rpc CountRulesReferencingSecret(CountRulesReferencingSecretRequest) returns (CountRulesReferencingSecretResponse);
 }
 
@@ -84,11 +85,15 @@ message EgressRule {
   EgressRuleEffect effect = 6;
 }
 
-// Attachment binding an egress rule to an agent.
+// Attachment binding an egress rule to an agent or environment.
 message EgressRuleAttachment {
   EntityMeta meta = 1;
   string rule_id = 2;
-  string agent_id = 3;
+  string agent_id = 3 [deprecated = true];
+  oneof target {
+    string environment_id = 4;
+    string agent_target_id = 5;
+  }
 }
 
 message CreateEgressRuleRequest {
@@ -142,7 +147,11 @@ message DeleteEgressRuleResponse {}
 
 message CreateEgressRuleAttachmentRequest {
   string rule_id = 1;
-  string agent_id = 2;
+  string agent_id = 2 [deprecated = true];
+  oneof target {
+    string environment_id = 3;
+    string agent_target_id = 6;
+  }
 }
 
 message CreateEgressRuleAttachmentResponse {
@@ -158,9 +167,11 @@ message DeleteEgressRuleAttachmentResponse {}
 message ListEgressRuleAttachmentsRequest {
   string organization_id = 1;
   optional string rule_id = 2;
-  optional string agent_id = 3;
+  optional string agent_id = 3 [deprecated = true];
   int32 page_size = 4;
   string page_token = 5;
+  optional string environment_id = 6;
+  optional string agent_target_id = 7;
 }
 
 message ListEgressRuleAttachmentsResponse {
@@ -173,6 +184,14 @@ message ListEgressRulesByAgentRequest {
 }
 
 message ListEgressRulesByAgentResponse {
+  repeated EgressRule egress_rules = 1;
+}
+
+message ListEgressRulesByEnvironmentRequest {
+  string environment_id = 1;
+}
+
+message ListEgressRulesByEnvironmentResponse {
   repeated EgressRule egress_rules = 1;
 }
 

--- a/proto/agynio/api/gateway/v1/agents.proto
+++ b/proto/agynio/api/gateway/v1/agents.proto
@@ -18,6 +18,21 @@ service AgentsGateway {
   rpc ListAgentRoles(agynio.api.agents.v1.ListAgentRolesRequest) returns (agynio.api.agents.v1.ListAgentRolesResponse);
   rpc ListMyAgentRoles(agynio.api.agents.v1.ListMyAgentRolesRequest) returns (agynio.api.agents.v1.ListMyAgentRolesResponse);
 
+  // --- Environments ---
+  rpc CreateEnvironment(agynio.api.agents.v1.CreateEnvironmentRequest) returns (agynio.api.agents.v1.CreateEnvironmentResponse);
+  rpc GetEnvironment(agynio.api.agents.v1.GetEnvironmentRequest) returns (agynio.api.agents.v1.GetEnvironmentResponse);
+  rpc UpdateEnvironment(agynio.api.agents.v1.UpdateEnvironmentRequest) returns (agynio.api.agents.v1.UpdateEnvironmentResponse);
+  rpc DeleteEnvironment(agynio.api.agents.v1.DeleteEnvironmentRequest) returns (agynio.api.agents.v1.DeleteEnvironmentResponse);
+  rpc ListEnvironments(agynio.api.agents.v1.ListEnvironmentsRequest) returns (agynio.api.agents.v1.ListEnvironmentsResponse);
+
+  // --- Sandboxes ---
+  rpc CreateSandbox(agynio.api.agents.v1.CreateSandboxRequest) returns (agynio.api.agents.v1.CreateSandboxResponse);
+  rpc GetSandbox(agynio.api.agents.v1.GetSandboxRequest) returns (agynio.api.agents.v1.GetSandboxResponse);
+  rpc ListSandboxes(agynio.api.agents.v1.ListSandboxesRequest) returns (agynio.api.agents.v1.ListSandboxesResponse);
+  rpc StopSandbox(agynio.api.agents.v1.StopSandboxRequest) returns (agynio.api.agents.v1.StopSandboxResponse);
+  rpc DeleteSandbox(agynio.api.agents.v1.DeleteSandboxRequest) returns (agynio.api.agents.v1.DeleteSandboxResponse);
+  rpc EnsureSandboxRunning(agynio.api.agents.v1.EnsureSandboxRunningRequest) returns (agynio.api.agents.v1.EnsureSandboxRunningResponse);
+
   // --- Agent Instances ---
   rpc CreateInstance(agynio.api.agents.v1.CreateInstanceRequest) returns (agynio.api.agents.v1.CreateInstanceResponse);
   rpc GetInstance(agynio.api.agents.v1.GetInstanceRequest) returns (agynio.api.agents.v1.GetInstanceResponse);

--- a/proto/agynio/api/gateway/v1/runners.proto
+++ b/proto/agynio/api/gateway/v1/runners.proto
@@ -16,6 +16,13 @@ service RunnersGateway {
   rpc DeleteRunner(agynio.api.runners.v1.DeleteRunnerRequest) returns (agynio.api.runners.v1.DeleteRunnerResponse);
   rpc EnrollRunner(agynio.api.runners.v1.EnrollRunnerRequest) returns (agynio.api.runners.v1.EnrollRunnerResponse);
 
+  // --- Flavors ---
+  rpc CreateFlavor(agynio.api.runners.v1.CreateFlavorRequest) returns (agynio.api.runners.v1.CreateFlavorResponse);
+  rpc GetFlavor(agynio.api.runners.v1.GetFlavorRequest) returns (agynio.api.runners.v1.GetFlavorResponse);
+  rpc UpdateFlavor(agynio.api.runners.v1.UpdateFlavorRequest) returns (agynio.api.runners.v1.UpdateFlavorResponse);
+  rpc DeleteFlavor(agynio.api.runners.v1.DeleteFlavorRequest) returns (agynio.api.runners.v1.DeleteFlavorResponse);
+  rpc ListFlavors(agynio.api.runners.v1.ListFlavorsRequest) returns (agynio.api.runners.v1.ListFlavorsResponse);
+
   // --- Workloads ---
   rpc ListWorkloads(agynio.api.runners.v1.ListWorkloadsRequest) returns (agynio.api.runners.v1.ListWorkloadsResponse);
   rpc ListWorkloadsByThread(agynio.api.runners.v1.ListWorkloadsByThreadRequest) returns (agynio.api.runners.v1.ListWorkloadsByThreadResponse);

--- a/proto/agynio/api/gateway/v1/terminal.proto
+++ b/proto/agynio/api/gateway/v1/terminal.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+
+package agynio.api.gateway.v1;
+
+import "agynio/api/terminal_proxy/v1/terminal_proxy.proto";
+
+option go_package = "github.com/agynio/api/gen/agynio/api/gateway/v1;gatewayv1";
+
+service TerminalGateway {
+  rpc CreateTerminalSession(CreateTerminalSessionRequest) returns (CreateTerminalSessionResponse);
+}
+
+message CreateTerminalSessionRequest {
+  string workload_id = 1;
+  string container_name = 2;
+  optional agynio.api.terminal_proxy.v1.TerminalCommand command = 3;
+}
+
+message CreateTerminalSessionResponse {
+  string ticket = 1;
+  string websocket_url = 2;
+  int32 expires_in_seconds = 3;
+}

--- a/proto/agynio/api/organizations/v1/organizations.proto
+++ b/proto/agynio/api/organizations/v1/organizations.proto
@@ -57,6 +57,8 @@ message Organization {
   string name = 2;
   google.protobuf.Timestamp created_at = 3;
   google.protobuf.Timestamp updated_at = 4;
+  string sandbox_default_idle_timeout = 5;
+  string sandbox_default_ttl = 6;
 }
 
 message CreateOrganizationRequest {
@@ -78,6 +80,8 @@ message GetOrganizationResponse {
 message UpdateOrganizationRequest {
   string id = 1; // UUID
   optional string name = 2;
+  optional string sandbox_default_idle_timeout = 3;
+  optional string sandbox_default_ttl = 4;
 }
 
 message UpdateOrganizationResponse {

--- a/proto/agynio/api/runners/v1/runners.proto
+++ b/proto/agynio/api/runners/v1/runners.proto
@@ -304,8 +304,9 @@ message Workload {
   EntityMeta meta = 1;
   string runner_id = 2;
   string thread_id = 3;
-  // Empty for sandbox-owned workloads.
-  string agent_id = 4;
+  // Deprecated: use agent_class_id. Unset/absent agent ownership is expressed
+  // by owner_kind plus agent_class_id presence, not by an empty string sentinel.
+  string agent_id = 4 [deprecated = true];
   string organization_id = 5;
   WorkloadStatus status = 6;
   repeated Container containers = 7;
@@ -323,23 +324,26 @@ message Workload {
   // programmatic parsing. When status is not FAILED, this value may be unset
   // or stale.
   optional string failure_message = 16;
-  // Denormalized display name for agent_id.
-  // Empty for sandbox-owned workloads.
-  string agent_name = 17;
+  // Deprecated: use agent_class_name. Unset/absent agent ownership is
+  // expressed by agent_class_name presence, not by an empty string sentinel.
+  string agent_name = 17 [deprecated = true];
   // Denormalized display name for runner_id.
   string runner_name = 18;
   WorkloadAgentState agent_state = 19;
   RuntimeOwnerKind owner_kind = 20;
   string owner_id = 21;
   optional string owner_name = 22;
+  optional string agent_class_id = 23;
+  optional string agent_class_name = 24;
 }
 
 message CreateWorkloadRequest {
   string id = 1;
   string runner_id = 2;
   string thread_id = 3;
-  // Empty for sandbox-owned workloads.
-  string agent_id = 4;
+  // Deprecated: use agent_class_id. Unset/absent agent ownership is expressed
+  // by owner_kind plus agent_class_id presence, not by an empty string sentinel.
+  string agent_id = 4 [deprecated = true];
   string organization_id = 5;
   WorkloadStatus status = 6;
   repeated Container containers = 7;
@@ -348,6 +352,7 @@ message CreateWorkloadRequest {
   int64 allocated_ram_bytes = 10;
   RuntimeOwnerKind owner_kind = 11;
   string owner_id = 12;
+  optional string agent_class_id = 13;
 }
 
 message CreateWorkloadResponse {
@@ -486,25 +491,32 @@ enum VolumeStatus {
 message Volume {
   EntityMeta meta = 1;
   optional string instance_id = 2;
-  // Empty for runtime-only sandbox workspace volumes.
-  string volume_id = 3;
+  // Deprecated: use volume_definition_id. Runtime-only sandbox workspace
+  // volumes are expressed by owner_kind plus volume_definition_id presence,
+  // not by an empty string sentinel.
+  string volume_id = 3 [deprecated = true];
   string thread_id = 4;
   string runner_id = 5;
-  // Empty for sandbox-owned volumes.
-  string agent_id = 6;
+  // Deprecated: use agent_class_id. Sandbox-owned volumes are expressed by
+  // owner_kind plus agent_class_id presence, not by an empty string sentinel.
+  string agent_id = 6 [deprecated = true];
   string organization_id = 7;
   string size_gb = 8;
   VolumeStatus status = 9;
   optional google.protobuf.Timestamp removed_at = 10;
   optional google.protobuf.Timestamp last_metering_sampled_at = 11;
-  // Denormalized display name for volume_id.
-  // Empty for runtime-only sandbox workspace volumes.
-  string volume_name = 12;
+  // Deprecated: use volume_definition_name. Runtime-only sandbox workspace
+  // volumes are expressed by volume_definition_name presence, not by an empty
+  // string sentinel.
+  string volume_name = 12 [deprecated = true];
   // Current attachments for this volume; empty when unattached.
   repeated Attachment attachments = 13;
   RuntimeOwnerKind owner_kind = 14;
   string owner_id = 15;
   optional string owner_name = 16;
+  optional string volume_definition_id = 17;
+  optional string agent_class_id = 18;
+  optional string volume_definition_name = 19;
 }
 
 enum AttachmentKind {
@@ -530,17 +542,22 @@ enum VolumeAttachmentFilterKind {
 
 message CreateVolumeRequest {
   string id = 1;
-  // Empty for runtime-only sandbox workspace volumes.
-  string volume_id = 2;
+  // Deprecated: use volume_definition_id. Runtime-only sandbox workspace
+  // volumes are expressed by owner_kind plus volume_definition_id presence,
+  // not by an empty string sentinel.
+  string volume_id = 2 [deprecated = true];
   string thread_id = 3;
   string runner_id = 4;
-  // Empty for sandbox-owned volumes.
-  string agent_id = 5;
+  // Deprecated: use agent_class_id. Sandbox-owned volumes are expressed by
+  // owner_kind plus agent_class_id presence, not by an empty string sentinel.
+  string agent_id = 5 [deprecated = true];
   string organization_id = 6;
   string size_gb = 7;
   VolumeStatus status = 8;
   RuntimeOwnerKind owner_kind = 9;
   string owner_id = 10;
+  optional string volume_definition_id = 11;
+  optional string agent_class_id = 12;
 }
 
 message CreateVolumeResponse {

--- a/proto/agynio/api/runners/v1/runners.proto
+++ b/proto/agynio/api/runners/v1/runners.proto
@@ -18,6 +18,13 @@ service RunnersService {
   rpc ValidateServiceToken(ValidateServiceTokenRequest) returns (ValidateServiceTokenResponse);
   rpc EnrollRunner(EnrollRunnerRequest) returns (EnrollRunnerResponse);
 
+  // --- Flavors ---
+  rpc CreateFlavor(CreateFlavorRequest) returns (CreateFlavorResponse);
+  rpc GetFlavor(GetFlavorRequest) returns (GetFlavorResponse);
+  rpc UpdateFlavor(UpdateFlavorRequest) returns (UpdateFlavorResponse);
+  rpc DeleteFlavor(DeleteFlavorRequest) returns (DeleteFlavorResponse);
+  rpc ListFlavors(ListFlavorsRequest) returns (ListFlavorsResponse);
+
   // --- Workload state ---
   rpc CreateWorkload(CreateWorkloadRequest) returns (CreateWorkloadResponse);
   rpc UpdateWorkload(UpdateWorkloadRequest) returns (UpdateWorkloadResponse);
@@ -49,6 +56,13 @@ message EntityMeta {
   string id = 1;
   google.protobuf.Timestamp created_at = 2;
   google.protobuf.Timestamp updated_at = 3;
+}
+
+message ComputeResources {
+  string requests_cpu = 1;
+  string requests_memory = 2;
+  string limits_cpu = 3;
+  string limits_memory = 4;
 }
 
 message SampledAtEntry {
@@ -156,8 +170,79 @@ message EnrollRunnerResponse {
 }
 
 // ===========================================================================
+// Flavor
+// ===========================================================================
+
+message Flavor {
+  EntityMeta meta = 1;
+  string runner_id = 2;
+  string name = 3;
+  ComputeResources resources = 4;
+  bool default = 5;
+  bool deprecated = 6;
+  optional string organization_id = 7;
+  string runner_name = 8;
+}
+
+message CreateFlavorRequest {
+  string runner_id = 1;
+  string name = 2;
+  ComputeResources resources = 3;
+  bool default = 4;
+}
+
+message CreateFlavorResponse {
+  Flavor flavor = 1;
+}
+
+message GetFlavorRequest {
+  string id = 1;
+}
+
+message GetFlavorResponse {
+  Flavor flavor = 1;
+}
+
+message UpdateFlavorRequest {
+  string id = 1;
+  optional string name = 2;
+  optional ComputeResources resources = 3;
+  optional bool default = 4;
+  optional bool deprecated = 5;
+}
+
+message UpdateFlavorResponse {
+  Flavor flavor = 1;
+}
+
+message DeleteFlavorRequest {
+  string id = 1;
+}
+
+message DeleteFlavorResponse {}
+
+message ListFlavorsRequest {
+  int32 page_size = 1;
+  string page_token = 2;
+  optional string runner_id = 3;
+  optional string organization_id = 4;
+  optional bool include_deprecated = 5;
+}
+
+message ListFlavorsResponse {
+  repeated Flavor flavors = 1;
+  string next_page_token = 2;
+}
+
+// ===========================================================================
 // Workload
 // ===========================================================================
+
+enum RuntimeOwnerKind {
+  RUNTIME_OWNER_KIND_UNSPECIFIED = 0;
+  RUNTIME_OWNER_KIND_AGENT_INSTANCE = 1;
+  RUNTIME_OWNER_KIND_SANDBOX = 2;
+}
 
 enum WorkloadStatus {
   WORKLOAD_STATUS_UNSPECIFIED = 0;
@@ -219,6 +304,7 @@ message Workload {
   EntityMeta meta = 1;
   string runner_id = 2;
   string thread_id = 3;
+  // Empty for sandbox-owned workloads.
   string agent_id = 4;
   string organization_id = 5;
   WorkloadStatus status = 6;
@@ -238,16 +324,21 @@ message Workload {
   // or stale.
   optional string failure_message = 16;
   // Denormalized display name for agent_id.
+  // Empty for sandbox-owned workloads.
   string agent_name = 17;
   // Denormalized display name for runner_id.
   string runner_name = 18;
   WorkloadAgentState agent_state = 19;
+  RuntimeOwnerKind owner_kind = 20;
+  string owner_id = 21;
+  optional string owner_name = 22;
 }
 
 message CreateWorkloadRequest {
   string id = 1;
   string runner_id = 2;
   string thread_id = 3;
+  // Empty for sandbox-owned workloads.
   string agent_id = 4;
   string organization_id = 5;
   WorkloadStatus status = 6;
@@ -255,6 +346,8 @@ message CreateWorkloadRequest {
   string ziti_identity_id = 8;
   int32 allocated_cpu_millicores = 9;
   int64 allocated_ram_bytes = 10;
+  RuntimeOwnerKind owner_kind = 11;
+  string owner_id = 12;
 }
 
 message CreateWorkloadResponse {
@@ -331,6 +424,8 @@ message ListWorkloadsFilter {
   optional google.protobuf.Timestamp started_after = 4;
   optional google.protobuf.Timestamp started_before = 5;
   optional bool pending_sample = 6;
+  repeated RuntimeOwnerKind owner_kind_in = 7;
+  repeated string owner_id_in = 8;
 }
 
 message ListWorkloadsByThreadRequest {
@@ -391,9 +486,11 @@ enum VolumeStatus {
 message Volume {
   EntityMeta meta = 1;
   optional string instance_id = 2;
+  // Empty for runtime-only sandbox workspace volumes.
   string volume_id = 3;
   string thread_id = 4;
   string runner_id = 5;
+  // Empty for sandbox-owned volumes.
   string agent_id = 6;
   string organization_id = 7;
   string size_gb = 8;
@@ -401,9 +498,13 @@ message Volume {
   optional google.protobuf.Timestamp removed_at = 10;
   optional google.protobuf.Timestamp last_metering_sampled_at = 11;
   // Denormalized display name for volume_id.
+  // Empty for runtime-only sandbox workspace volumes.
   string volume_name = 12;
   // Current attachments for this volume; empty when unattached.
   repeated Attachment attachments = 13;
+  RuntimeOwnerKind owner_kind = 14;
+  string owner_id = 15;
+  optional string owner_name = 16;
 }
 
 enum AttachmentKind {
@@ -429,13 +530,17 @@ enum VolumeAttachmentFilterKind {
 
 message CreateVolumeRequest {
   string id = 1;
+  // Empty for runtime-only sandbox workspace volumes.
   string volume_id = 2;
   string thread_id = 3;
   string runner_id = 4;
+  // Empty for sandbox-owned volumes.
   string agent_id = 5;
   string organization_id = 6;
   string size_gb = 7;
   VolumeStatus status = 8;
+  RuntimeOwnerKind owner_kind = 9;
+  string owner_id = 10;
 }
 
 message CreateVolumeResponse {
@@ -481,6 +586,8 @@ message ListVolumesFilter {
   repeated VolumeAttachmentFilterKind attached_to_kind_in = 3;
   optional bool pending_sample = 4;
   optional string volume_name_substring = 5;
+  repeated RuntimeOwnerKind owner_kind_in = 6;
+  repeated string owner_id_in = 7;
 }
 
 message ListVolumesRequest {

--- a/proto/agynio/api/terminal_proxy/v1/terminal_proxy.proto
+++ b/proto/agynio/api/terminal_proxy/v1/terminal_proxy.proto
@@ -10,6 +10,9 @@ service TerminalProxyService {
 }
 
 message IssueTicketRequest {
+  // Authenticated identity supplied by Gateway from request context. This
+  // field is internal service-to-service data and must never come from client
+  // input.
   string identity_id = 1;
   string workload_id = 2;
   string container_name = 3;

--- a/proto/agynio/api/terminal_proxy/v1/terminal_proxy.proto
+++ b/proto/agynio/api/terminal_proxy/v1/terminal_proxy.proto
@@ -1,0 +1,34 @@
+syntax = "proto3";
+
+package agynio.api.terminal_proxy.v1;
+
+option go_package = "github.com/agynio/api/gen/agynio/api/terminal_proxy/v1;terminalproxyv1";
+
+// TerminalProxyService issues short-lived terminal session tickets.
+service TerminalProxyService {
+  rpc IssueTicket(IssueTicketRequest) returns (IssueTicketResponse);
+}
+
+message IssueTicketRequest {
+  string identity_id = 1;
+  string workload_id = 2;
+  string container_name = 3;
+  TerminalCommand command = 4;
+}
+
+message IssueTicketResponse {
+  string ticket = 1;
+  string websocket_url = 2;
+  int32 expires_in_seconds = 3;
+}
+
+message TerminalCommand {
+  oneof command {
+    string shell = 1;
+    TerminalArgv argv = 2;
+  }
+}
+
+message TerminalArgv {
+  repeated string argv = 1;
+}


### PR DESCRIPTION
## Summary

Implements the first dependency-safe API contract slice for architecture issue #162:

- Adds sandbox resource contracts to Agents and Gateway.
- Adds environment contracts needed by sandboxes.
- Adds flavor contracts and generalized runtime ownership fields for Runners.
- Adds Terminal Proxy ticket issuance and Gateway terminal session contracts.
- Adds organization sandbox default TTL/idle-timeout fields.

This PR is intentionally contracts-only so implementation repos can depend on stable generated API shapes before service-specific storage, authorization, orchestration, CLI, and proxy work begins.

References agynio/architecture#162.

## Repo / PR breakdown proposed from inspection

1. `agynio/api` (this PR): shared contracts for sandboxes, environments/flavors, generalized runner ownership, terminal tickets, org sandbox defaults.
2. `agynio/agents`: sandbox CRUD/state/name generation/default snapshotting, environment deletion guard, `last_session_at`, sandbox notifications.
3. `agynio/authorization`: OpenFGA sandbox type/relations and tuple lifecycle helpers.
4. `agynio/runners` and `agynio/k8s-runner`: DB/API generalized ownership, nullable/sandbox display handling, runtime workspace volumes.
5. `agynio/agents-orchestrator`: sandbox reconciler, holder workload assembly, identity attributes, TTL/idle lifecycle, metering labels.
6. `agynio/agynd-cli` and init-image repos: sandbox holder mode without inbox consumption.
7. new `agynio/terminal-proxy`: ticket issuing/validation and WebSocket to Runner.Exec bridge.
8. `agynio/gateway`: expose `CreateTerminalSession` and sandbox API authorization.
9. `agynio/agyn-cli`: `agyn sandbox` command group and TTY attach.
10. `agynio/console-app`: sandbox list/detail/terminal/notification UX.
11. attribution services (`llm-proxy`, `tracing`, `egress-gateway`, metering consumers): sandbox identity resolution and labels.

## Test & lint summary

- `CGO_ENABLED=0 GOPROXY=direct GOSUMDB=off go run github.com/bufbuild/buf/cmd/buf@latest lint` — passed, 0 failures.
- `CGO_ENABLED=0 GOPROXY=direct GOSUMDB=off go run github.com/bufbuild/buf/cmd/buf@latest breaking --against '.git#branch=main'` — passed, 0 failures.

Notes: `buf` was not installed in the base workspace. `go run` required `CGO_ENABLED=0`; direct module fetching was used after checksum DNS lookup failed transiently.