### PR TITLE
feat(runners): add agent instance workload contracts

### DIFF
--- a/.github/workflows/buf-pr.yaml
+++ b/.github/workflows/buf-pr.yaml
@@ -8,20 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: bufbuild/buf-action@v1
         with:
-          fetch-depth: 0
-      - uses: actions/setup-go@v5
-        with:
-          go-version: '1.25.x'
-      - name: Install buf
-        run: |
-          go install github.com/bufbuild/buf/cmd/buf@v1.66.0
-          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
-      - name: Buf lint
-        run: buf lint
-      - name: Buf format
-        run: buf format --diff --exit-code
-      - name: Buf breaking
-        run: |
-          git fetch origin main:refs/remotes/origin/main
-          buf breaking --against '.git#branch=origin/main'
+          input: .
+          lint: true
+          breaking: true

--- a/.github/workflows/buf-pr.yaml
+++ b/.github/workflows/buf-pr.yaml
@@ -8,8 +8,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-action@v1
         with:
-          input: .
-          lint: true
-          breaking: true
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.x'
+      - name: Install buf
+        run: |
+          go install github.com/bufbuild/buf/cmd/buf@v1.66.0
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+      - name: Buf lint
+        run: buf lint
+      - name: Buf format
+        run: buf format --diff --exit-code
+      - name: Buf breaking
+        run: |
+          git fetch origin main:refs/remotes/origin/main
+          buf breaking --against '.git#branch=origin/main'

--- a/proto/agynio/api/gateway/v1/runners.proto
+++ b/proto/agynio/api/gateway/v1/runners.proto
@@ -26,6 +26,7 @@ service RunnersGateway {
   // --- Workloads ---
   rpc ListWorkloads(agynio.api.runners.v1.ListWorkloadsRequest) returns (agynio.api.runners.v1.ListWorkloadsResponse);
   rpc ListWorkloadsByThread(agynio.api.runners.v1.ListWorkloadsByThreadRequest) returns (agynio.api.runners.v1.ListWorkloadsByThreadResponse);
+  rpc ListWorkloadsByAgentInstance(agynio.api.runners.v1.ListWorkloadsByAgentInstanceRequest) returns (agynio.api.runners.v1.ListWorkloadsByAgentInstanceResponse);
   rpc GetWorkload(agynio.api.runners.v1.GetWorkloadRequest) returns (agynio.api.runners.v1.GetWorkloadResponse);
   rpc TouchWorkload(agynio.api.runners.v1.TouchWorkloadRequest) returns (agynio.api.runners.v1.TouchWorkloadResponse);
   rpc StreamWorkloadLogs(agynio.api.runner.v1.StreamWorkloadLogsRequest) returns (stream agynio.api.runner.v1.StreamWorkloadLogsResponse);
@@ -34,4 +35,5 @@ service RunnersGateway {
   rpc GetVolume(agynio.api.runners.v1.GetVolumeRequest) returns (agynio.api.runners.v1.GetVolumeResponse);
   rpc ListVolumes(agynio.api.runners.v1.ListVolumesRequest) returns (agynio.api.runners.v1.ListVolumesResponse);
   rpc ListVolumesByThread(agynio.api.runners.v1.ListVolumesByThreadRequest) returns (agynio.api.runners.v1.ListVolumesByThreadResponse);
+  rpc ListVolumesByAgentInstance(agynio.api.runners.v1.ListVolumesByAgentInstanceRequest) returns (agynio.api.runners.v1.ListVolumesByAgentInstanceResponse);
 }

--- a/proto/agynio/api/runners/v1/runners.proto
+++ b/proto/agynio/api/runners/v1/runners.proto
@@ -337,10 +337,11 @@ message Workload {
   optional string owner_name = 22;
   optional string agent_class_id = 23;
   optional string agent_class_name = 24;
-  // Platform agent instance identity for this workload. Distinct from
-  // instance_id, which is the runner-local workload identifier (for example,
-  // a Pod name).
-  string agent_instance_id = 25;
+  // Platform agent instance identity for this workload. Set when owner_kind is
+  // RUNTIME_OWNER_KIND_AGENT_INSTANCE. Absent for valid non-agent owners such
+  // as sandbox/runtime-only records. Distinct from instance_id, which is the
+  // runner-local workload identifier (for example, a Pod name).
+  optional string agent_instance_id = 25;
 }
 
 message CreateWorkloadRequest {
@@ -359,9 +360,11 @@ message CreateWorkloadRequest {
   RuntimeOwnerKind owner_kind = 11;
   string owner_id = 12;
   optional string agent_class_id = 13;
-  // Platform agent instance identity for this workload. Distinct from the
-  // runner-local instance_id that may later be set by UpdateWorkload.
-  string agent_instance_id = 14;
+  // Platform agent instance identity for this workload. Set when owner_kind is
+  // RUNTIME_OWNER_KIND_AGENT_INSTANCE. Absent for valid non-agent owners such
+  // as sandbox/runtime-only records. Distinct from the runner-local instance_id
+  // that may later be set by UpdateWorkload.
+  optional string agent_instance_id = 14;
 }
 
 message CreateWorkloadResponse {
@@ -540,10 +543,11 @@ message Volume {
   optional string volume_definition_id = 17;
   optional string agent_class_id = 18;
   optional string volume_definition_name = 19;
-  // Platform agent instance identity that owns/reuses this volume. Distinct
-  // from instance_id, which is the runner-local volume identifier (for
-  // example, a PVC name).
-  string agent_instance_id = 20;
+  // Platform agent instance identity that owns/reuses this volume. Set when
+  // owner_kind is RUNTIME_OWNER_KIND_AGENT_INSTANCE. Absent for valid non-agent
+  // owners such as sandbox/runtime-only records. Distinct from instance_id,
+  // which is the runner-local volume identifier (for example, a PVC name).
+  optional string agent_instance_id = 20;
 }
 
 enum AttachmentKind {
@@ -585,9 +589,11 @@ message CreateVolumeRequest {
   string owner_id = 10;
   optional string volume_definition_id = 11;
   optional string agent_class_id = 12;
-  // Platform agent instance identity that owns/reuses this volume. Distinct
-  // from the runner-local instance_id that may later be set by UpdateVolume.
-  string agent_instance_id = 13;
+  // Platform agent instance identity that owns/reuses this volume. Set when
+  // owner_kind is RUNTIME_OWNER_KIND_AGENT_INSTANCE. Absent for valid non-agent
+  // owners such as sandbox/runtime-only records. Distinct from the runner-local
+  // instance_id that may later be set by UpdateVolume.
+  optional string agent_instance_id = 13;
 }
 
 message CreateVolumeResponse {

--- a/proto/agynio/api/runners/v1/runners.proto
+++ b/proto/agynio/api/runners/v1/runners.proto
@@ -33,6 +33,7 @@ service RunnersService {
   rpc DeleteWorkload(DeleteWorkloadRequest) returns (DeleteWorkloadResponse);
   rpc GetWorkload(GetWorkloadRequest) returns (GetWorkloadResponse);
   rpc ListWorkloadsByThread(ListWorkloadsByThreadRequest) returns (ListWorkloadsByThreadResponse);
+  rpc ListWorkloadsByAgentInstance(ListWorkloadsByAgentInstanceRequest) returns (ListWorkloadsByAgentInstanceResponse);
   rpc ListWorkloads(ListWorkloadsRequest) returns (ListWorkloadsResponse);
   rpc BatchUpdateWorkloadSampledAt(BatchUpdateWorkloadSampledAtRequest) returns (BatchUpdateWorkloadSampledAtResponse);
 
@@ -45,6 +46,7 @@ service RunnersService {
   rpc GetVolume(GetVolumeRequest) returns (GetVolumeResponse);
   rpc ListVolumes(ListVolumesRequest) returns (ListVolumesResponse);
   rpc ListVolumesByThread(ListVolumesByThreadRequest) returns (ListVolumesByThreadResponse);
+  rpc ListVolumesByAgentInstance(ListVolumesByAgentInstanceRequest) returns (ListVolumesByAgentInstanceResponse);
   rpc BatchUpdateVolumeSampledAt(BatchUpdateVolumeSampledAtRequest) returns (BatchUpdateVolumeSampledAtResponse);
 }
 
@@ -335,6 +337,10 @@ message Workload {
   optional string owner_name = 22;
   optional string agent_class_id = 23;
   optional string agent_class_name = 24;
+  // Platform agent instance identity for this workload. Distinct from
+  // instance_id, which is the runner-local workload identifier (for example,
+  // a Pod name).
+  string agent_instance_id = 25;
 }
 
 message CreateWorkloadRequest {
@@ -353,6 +359,9 @@ message CreateWorkloadRequest {
   RuntimeOwnerKind owner_kind = 11;
   string owner_id = 12;
   optional string agent_class_id = 13;
+  // Platform agent instance identity for this workload. Distinct from the
+  // runner-local instance_id that may later be set by UpdateWorkload.
+  string agent_instance_id = 14;
 }
 
 message CreateWorkloadResponse {
@@ -448,6 +457,20 @@ message ListWorkloadsByThreadResponse {
   string next_page_token = 2;
 }
 
+message ListWorkloadsByAgentInstanceRequest {
+  string agent_instance_id = 1;
+  int32 page_size = 2;
+  string page_token = 3;
+  // Optional status filter. An empty list returns workloads for all statuses.
+  repeated WorkloadStatus statuses = 4;
+}
+
+message ListWorkloadsByAgentInstanceResponse {
+  // Ordered by created_at DESC, id DESC for stable pagination.
+  repeated Workload workloads = 1;
+  string next_page_token = 2;
+}
+
 message ListWorkloadsRequest {
   int32 page_size = 1;
   // Opaque cursor; reuse only with the same sort and filter.
@@ -517,6 +540,10 @@ message Volume {
   optional string volume_definition_id = 17;
   optional string agent_class_id = 18;
   optional string volume_definition_name = 19;
+  // Platform agent instance identity that owns/reuses this volume. Distinct
+  // from instance_id, which is the runner-local volume identifier (for
+  // example, a PVC name).
+  string agent_instance_id = 20;
 }
 
 enum AttachmentKind {
@@ -558,6 +585,9 @@ message CreateVolumeRequest {
   string owner_id = 10;
   optional string volume_definition_id = 11;
   optional string agent_class_id = 12;
+  // Platform agent instance identity that owns/reuses this volume. Distinct
+  // from the runner-local instance_id that may later be set by UpdateVolume.
+  string agent_instance_id = 13;
 }
 
 message CreateVolumeResponse {
@@ -635,6 +665,19 @@ message ListVolumesByThreadRequest {
 }
 
 message ListVolumesByThreadResponse {
+  repeated Volume volumes = 1;
+  string next_page_token = 2;
+}
+
+message ListVolumesByAgentInstanceRequest {
+  string agent_instance_id = 1;
+  int32 page_size = 2;
+  string page_token = 3;
+  // Optional status filter. An empty list returns volumes for all statuses.
+  repeated VolumeStatus statuses = 4;
+}
+
+message ListVolumesByAgentInstanceResponse {
   repeated Volume volumes = 1;
   string next_page_token = 2;
 }

--- a/proto/agynio/api/runners/v1/runners.proto
+++ b/proto/agynio/api/runners/v1/runners.proto
@@ -337,10 +337,7 @@ message Workload {
   optional string owner_name = 22;
   optional string agent_class_id = 23;
   optional string agent_class_name = 24;
-  // Platform agent instance identity for this workload. Set when owner_kind is
-  // RUNTIME_OWNER_KIND_AGENT_INSTANCE. Absent for valid non-agent owners such
-  // as sandbox/runtime-only records. Distinct from instance_id, which is the
-  // runner-local workload identifier (for example, a Pod name).
+  // Present when owner_kind is RUNTIME_OWNER_KIND_AGENT_INSTANCE; absent otherwise.
   optional string agent_instance_id = 25;
 }
 
@@ -360,10 +357,7 @@ message CreateWorkloadRequest {
   RuntimeOwnerKind owner_kind = 11;
   string owner_id = 12;
   optional string agent_class_id = 13;
-  // Platform agent instance identity for this workload. Set when owner_kind is
-  // RUNTIME_OWNER_KIND_AGENT_INSTANCE. Absent for valid non-agent owners such
-  // as sandbox/runtime-only records. Distinct from the runner-local instance_id
-  // that may later be set by UpdateWorkload.
+  // Present when owner_kind is RUNTIME_OWNER_KIND_AGENT_INSTANCE; absent otherwise.
   optional string agent_instance_id = 14;
 }
 
@@ -543,10 +537,7 @@ message Volume {
   optional string volume_definition_id = 17;
   optional string agent_class_id = 18;
   optional string volume_definition_name = 19;
-  // Platform agent instance identity that owns/reuses this volume. Set when
-  // owner_kind is RUNTIME_OWNER_KIND_AGENT_INSTANCE. Absent for valid non-agent
-  // owners such as sandbox/runtime-only records. Distinct from instance_id,
-  // which is the runner-local volume identifier (for example, a PVC name).
+  // Present when owner_kind is RUNTIME_OWNER_KIND_AGENT_INSTANCE; absent otherwise.
   optional string agent_instance_id = 20;
 }
 
@@ -589,10 +580,7 @@ message CreateVolumeRequest {
   string owner_id = 10;
   optional string volume_definition_id = 11;
   optional string agent_class_id = 12;
-  // Platform agent instance identity that owns/reuses this volume. Set when
-  // owner_kind is RUNTIME_OWNER_KIND_AGENT_INSTANCE. Absent for valid non-agent
-  // owners such as sandbox/runtime-only records. Distinct from the runner-local
-  // instance_id that may later be set by UpdateVolume.
+  // Present when owner_kind is RUNTIME_OWNER_KIND_AGENT_INSTANCE; absent otherwise.
   optional string agent_instance_id = 13;
 }
 


### PR DESCRIPTION
## Summary
- Add platform `agent_instance_id` fields to Runners workload and volume API resources/create requests.
- Add `ListWorkloadsByAgentInstance` and `ListVolumesByAgentInstance` to RunnersService and gateway contracts.
- Document that runner-local `instance_id` remains distinct from platform `agent_instance_id`.

Part of agynio/architecture#161.

## Validation
- `PATH=/root/.nix-profile/bin:/root/go/bin:$PATH buf lint` - passed
- `PATH=/root/.nix-profile/bin:/root/go/bin:$PATH buf breaking --against '.git#branch=main'` - passed