### PR TITLE
feat(agents): add sandbox runtime state contract

### DIFF
--- a/proto/agynio/api/agents/v1/agents.proto
+++ b/proto/agynio/api/agents/v1/agents.proto
@@ -39,6 +39,7 @@ service AgentsService {
   rpc StopSandbox(StopSandboxRequest) returns (StopSandboxResponse);
   rpc DeleteSandbox(DeleteSandboxRequest) returns (DeleteSandboxResponse);
   rpc EnsureSandboxRunning(EnsureSandboxRunningRequest) returns (EnsureSandboxRunningResponse);
+  rpc UpdateSandboxRuntimeState(UpdateSandboxRuntimeStateRequest) returns (UpdateSandboxRuntimeStateResponse);
   rpc UpdateSandboxLastSession(UpdateSandboxLastSessionRequest) returns (UpdateSandboxLastSessionResponse);
 
   // --- Agent Instances ---
@@ -595,6 +596,19 @@ message EnsureSandboxRunningRequest {
 }
 
 message EnsureSandboxRunningResponse {
+  Sandbox sandbox = 1;
+}
+
+message UpdateSandboxRuntimeStateRequest {
+  string id = 1;
+  optional SandboxStatus status = 2;
+  oneof workload_id_update {
+    string workload_id = 3;
+    bool clear_workload_id = 4;
+  }
+}
+
+message UpdateSandboxRuntimeStateResponse {
   Sandbox sandbox = 1;
 }
 


### PR DESCRIPTION
## Summary

- Adds the internal Agents `UpdateSandboxRuntimeState` RPC for runtime-owned sandbox status/workload updates.
- Supports optional status updates, setting `workload_id`, and explicit `clear_workload_id` behavior.
- Keeps the contract in AgentsService only; Gateway/public forwarding is intentionally unchanged.

Refs agynio/agents#63
Refs agynio/architecture#162

## Validation

- `buf lint` — passed
- `buf breaking --against '.git#branch=main'` — passed