### PR TITLE
Runner-reported catalogs, environment placement, and email_verified

### DIFF
--- a/proto/agynio/api/agents/v1/agents.proto
+++ b/proto/agynio/api/agents/v1/agents.proto
@@ -457,16 +457,27 @@ message Environment {
   EntityMeta meta = 1;
   string organization_id = 2;
   string name = 3;
-  string flavor_id = 4;
+  // Superseded by runner_id + flavor: placement is now environment to runner
+  // directly, with the flavor named within that runner's catalog.
+  string flavor_id = 4 [deprecated = true];
   string image = 5;
-  string flavor_name = 6;
+  string flavor_name = 6 [deprecated = true];
+  // The runner this environment places workloads on.
+  string runner_id = 7;
+  // Catalog entry name, resolved against the runner's reported catalog at
+  // workload start. Empty resolves to the runner's default flavor.
+  // Deliberately not validated here: platform resources and runner
+  // configuration may be applied in either order.
+  string flavor = 8;
 }
 
 message CreateEnvironmentRequest {
   string organization_id = 1;
   string name = 2;
-  string flavor_id = 3;
+  string flavor_id = 3 [deprecated = true];
   string image = 4;
+  string runner_id = 5;
+  string flavor = 6;
 }
 
 message CreateEnvironmentResponse {
@@ -484,8 +495,10 @@ message GetEnvironmentResponse {
 message UpdateEnvironmentRequest {
   string id = 1; // UUID
   optional string name = 2;
-  optional string flavor_id = 3;
+  optional string flavor_id = 3 [deprecated = true];
   optional string image = 4;
+  optional string runner_id = 5;
+  optional string flavor = 6;
 }
 
 message UpdateEnvironmentResponse {

--- a/proto/agynio/api/gateway/v1/runners.proto
+++ b/proto/agynio/api/gateway/v1/runners.proto
@@ -15,6 +15,9 @@ service RunnersGateway {
   rpc UpdateRunner(agynio.api.runners.v1.UpdateRunnerRequest) returns (agynio.api.runners.v1.UpdateRunnerResponse);
   rpc DeleteRunner(agynio.api.runners.v1.DeleteRunnerRequest) returns (agynio.api.runners.v1.DeleteRunnerResponse);
   rpc EnrollRunner(agynio.api.runners.v1.EnrollRunnerRequest) returns (agynio.api.runners.v1.EnrollRunnerResponse);
+  // Service-token authenticated, like EnrollRunner: the runner reports the
+  // catalog it declares in its own configuration.
+  rpc ReportRunnerCatalog(agynio.api.runners.v1.ReportRunnerCatalogRequest) returns (agynio.api.runners.v1.ReportRunnerCatalogResponse);
 
   // --- Flavors ---
   rpc CreateFlavor(agynio.api.runners.v1.CreateFlavorRequest) returns (agynio.api.runners.v1.CreateFlavorResponse);
@@ -22,6 +25,7 @@ service RunnersGateway {
   rpc UpdateFlavor(agynio.api.runners.v1.UpdateFlavorRequest) returns (agynio.api.runners.v1.UpdateFlavorResponse);
   rpc DeleteFlavor(agynio.api.runners.v1.DeleteFlavorRequest) returns (agynio.api.runners.v1.DeleteFlavorResponse);
   rpc ListFlavors(agynio.api.runners.v1.ListFlavorsRequest) returns (agynio.api.runners.v1.ListFlavorsResponse);
+  rpc ListStorageClasses(agynio.api.runners.v1.ListStorageClassesRequest) returns (agynio.api.runners.v1.ListStorageClassesResponse);
 
   // --- Workloads ---
   rpc ListWorkloads(agynio.api.runners.v1.ListWorkloadsRequest) returns (agynio.api.runners.v1.ListWorkloadsResponse);

--- a/proto/agynio/api/runners/v1/runners.proto
+++ b/proto/agynio/api/runners/v1/runners.proto
@@ -19,11 +19,29 @@ service RunnersService {
   rpc EnrollRunner(EnrollRunnerRequest) returns (EnrollRunnerResponse);
 
   // --- Flavors ---
-  rpc CreateFlavor(CreateFlavorRequest) returns (CreateFlavorResponse);
-  rpc GetFlavor(GetFlavorRequest) returns (GetFlavorResponse);
-  rpc UpdateFlavor(UpdateFlavorRequest) returns (UpdateFlavorResponse);
-  rpc DeleteFlavor(DeleteFlavorRequest) returns (DeleteFlavorResponse);
+  // Superseded by ReportRunnerCatalog: flavors are declared in the runner's
+  // own configuration, not managed through platform APIs. Retained so existing
+  // callers keep compiling while they migrate; the service does not implement
+  // them.
+  rpc CreateFlavor(CreateFlavorRequest) returns (CreateFlavorResponse) {
+    option deprecated = true;
+  }
+  rpc GetFlavor(GetFlavorRequest) returns (GetFlavorResponse) {
+    option deprecated = true;
+  }
+  rpc UpdateFlavor(UpdateFlavorRequest) returns (UpdateFlavorResponse) {
+    option deprecated = true;
+  }
+  rpc DeleteFlavor(DeleteFlavorRequest) returns (DeleteFlavorResponse) {
+    option deprecated = true;
+  }
   rpc ListFlavors(ListFlavorsRequest) returns (ListFlavorsResponse);
+
+  // --- Runner catalog ---
+  // The catalog is declared in the runner's own configuration and reported
+  // here; a report replaces the runner's stored catalog wholesale.
+  rpc ReportRunnerCatalog(ReportRunnerCatalogRequest) returns (ReportRunnerCatalogResponse);
+  rpc ListStorageClasses(ListStorageClassesRequest) returns (ListStorageClassesResponse);
 
   // --- Workload state ---
   rpc CreateWorkload(CreateWorkloadRequest) returns (CreateWorkloadResponse);
@@ -176,7 +194,10 @@ message EnrollRunnerResponse {
 // ===========================================================================
 
 message Flavor {
-  EntityMeta meta = 1;
+  // Catalog entries have no platform identity — they are named entries in a
+  // runner's report, replaced wholesale on the next report. Unset for reported
+  // entries; retained for callers still reading it.
+  EntityMeta meta = 1 [deprecated = true];
   string runner_id = 2;
   string name = 3;
   ComputeResources resources = 4;
@@ -233,6 +254,58 @@ message ListFlavorsRequest {
 
 message ListFlavorsResponse {
   repeated Flavor flavors = 1;
+  string next_page_token = 2;
+}
+
+message StorageClass {
+  string runner_id = 1;
+  string name = 2;
+  bool default = 3;
+  bool deprecated = 4;
+  optional string organization_id = 5;
+  string runner_name = 6;
+}
+
+// FlavorEntry and StorageClassEntry are what a runner declares in its own
+// configuration; the platform-scoped fields above are filled in on read.
+message FlavorEntry {
+  string name = 1;
+  ComputeResources resources = 2;
+  bool default = 3;
+  bool deprecated = 4;
+}
+
+message StorageClassEntry {
+  string name = 1;
+  bool default = 2;
+  bool deprecated = 3;
+}
+
+message ReportRunnerCatalogRequest {
+  string runner_id = 1;
+  // Authenticates the report, as for EnrollRunner.
+  string service_token = 2;
+  repeated FlavorEntry flavors = 3;
+  repeated StorageClassEntry storage_classes = 4;
+  repeated string capabilities = 5;
+}
+
+message ReportRunnerCatalogResponse {
+  int32 flavor_count = 1;
+  int32 storage_class_count = 2;
+  int32 capability_count = 3;
+}
+
+message ListStorageClassesRequest {
+  int32 page_size = 1;
+  string page_token = 2;
+  optional string runner_id = 3;
+  optional string organization_id = 4;
+  optional bool include_deprecated = 5;
+}
+
+message ListStorageClassesResponse {
+  repeated StorageClass storage_classes = 1;
   string next_page_token = 2;
 }
 

--- a/proto/agynio/api/users/v1/users.proto
+++ b/proto/agynio/api/users/v1/users.proto
@@ -96,6 +96,9 @@ message ResolveOrCreateUserRequest {
   string email = 3;
   string photo_url = 4;
   optional string preferred_username = 5;
+  // Whether the IdP asserts the email claim is verified. Required for the
+  // first-admin claim when first_admin_email is configured.
+  bool email_verified = 6;
 }
 
 message ResolveOrCreateUserResponse {


### PR DESCRIPTION
Contract changes for three specs. Everything is additive — `buf breaking` passes against `main`, and `buf.lock` pins commits, so no consumer moves until it chooses to.

## Runner-reported catalogs

Implements `changes/2026-07-18-runner-reported-catalogs.md`, which supersedes the flavor-management model.

Flavors, storage classes and capabilities are declared in a runner's own configuration and reported through the new `ReportRunnerCatalog`, which replaces the runner's stored catalog wholesale. Every catalog entry needs a runner-side implementation anyway — a flavor is only real if that runner can allocate the resources, a storage class only if it maps to a StorageClass in that cluster — so platform-managed copies would duplicate the declaration and drift from it.

`ListStorageClasses` joins `ListFlavors` as the storage half. `Flavor.meta` is deprecated: reported entries have no platform identity.

## Environment placement

`Environment` gains `runner_id` and `flavor` (a name, resolved against the runner's reported catalog at workload start). Placement becomes environment → runner directly.

The old `flavor_id` fields stay at their numbers, marked deprecated. Reusing those numbers would have been worse than removing them: `flavor_id` and `runner_id` are both `string`, so an existing environment's stored flavor UUID would have decoded silently as a runner id rather than failing.

## email_verified

`ResolveOrCreateUserRequest` carries `email_verified`, for the first-admin claim in `changes/2026-07-26-promote-first-login-cluster-admin.md`. The claim is gated on a verified address so that anyone able to register with the IdP cannot assert the configured admin's address and take the cluster.

## Why this merges first

Every service generates Go from the published module. Until this is released, the implementations of all three specs — across runners, k8s-runner, agents, agents-orchestrator, gateway, llm-proxy and users — cannot build in CI or in devspace dev containers, so none of it can be verified against a live cluster.

The deprecated RPCs (`CreateFlavor`, `UpdateFlavor`, `DeleteFlavor`, `GetFlavor`) are retained and unimplemented server-side; they can be removed once no caller references them.