### PR TITLE
Name the organization when listing envs and image pull secret attachments

### DIFF
--- a/proto/agynio/api/agents/v1/agents.proto
+++ b/proto/agynio/api/agents/v1/agents.proto
@@ -799,6 +799,10 @@ message DeleteImagePullSecretAttachmentResponse {}
 message ListImagePullSecretAttachmentsRequest {
   int32 page_size = 1;
   string page_token = 2;
+  // The organization whose image pull secret attachments are listed. Required
+  // of a caller presenting an identity; the remaining ids only narrow the
+  // result within it.
+  string organization_id = 8; // UUID
   string image_pull_secret_id = 3;
   string agent_id = 4;
   string mcp_id = 5;

--- a/proto/agynio/api/agents/v1/agents.proto
+++ b/proto/agynio/api/agents/v1/agents.proto
@@ -1067,6 +1067,9 @@ message DeleteEnvResponse {}
 message ListEnvsRequest {
   int32 page_size = 1;
   string page_token = 2;
+  // The organization whose envs are listed. Required of a caller presenting an
+  // identity; the remaining ids only narrow the result within it.
+  string organization_id = 7; // UUID
   string agent_id = 3;
   string mcp_id = 4;
   string hook_id = 5;


### PR DESCRIPTION
Adds `organization_id` to `ListEnvsRequest` and `ListImagePullSecretAttachmentsRequest`.

Both RPCs returned rows for any organization the caller named, with no authorization check at all — knowing the id was the permission. Neither table was org-scoped, which is why the service leaned on a "at least one filter must be provided" guard instead: an unfiltered list would have crossed tenants. The agents service now scopes both tables by organization and checks `member` on it, per the authorization table already in `agents-service.md`; these fields are how a caller names the organization being listed.

Purely additive — no field is renumbered or repurposed. `buf lint` and `buf breaking` against `main` both pass.

The agents-side implementation is ready and blocked on this being published: it compiles against the BSR module, so `ListEnvs` and `ListImagePullSecretAttachments` cannot reference the field until then.