### PR TITLE
feat(metering): bill compute per flavor

### DIFF
--- a/proto/agynio/api/metering/v1/metering.proto
+++ b/proto/agynio/api/metering/v1/metering.proto
@@ -17,6 +17,10 @@ enum Unit {
   UNIT_CORE_SECONDS = 2;
   UNIT_GB_SECONDS = 3;
   UNIT_COUNT = 4;
+  // A workload occupying one flavor for one second. Compute is billed per
+  // flavor: CPU and memory are two numbers inside one, so billing them
+  // separately re-derives a shape the platform already names.
+  UNIT_FLAVOR_SECONDS = 5;
 }
 
 message UsageRecord {

--- a/proto/agynio/api/metering/v1/metering.proto
+++ b/proto/agynio/api/metering/v1/metering.proto
@@ -17,9 +17,6 @@ enum Unit {
   UNIT_CORE_SECONDS = 2;
   UNIT_GB_SECONDS = 3;
   UNIT_COUNT = 4;
-  // A workload occupying one flavor for one second. Compute is billed per
-  // flavor: CPU and memory are two numbers inside one, so billing them
-  // separately re-derives a shape the platform already names.
   UNIT_FLAVOR_SECONDS = 5;
 }
 

--- a/proto/agynio/api/runners/v1/runners.proto
+++ b/proto/agynio/api/runners/v1/runners.proto
@@ -392,6 +392,12 @@ message Workload {
   optional google.protobuf.Timestamp removed_at = 12;
   int32 allocated_cpu_millicores = 13;
   int64 allocated_ram_bytes = 14;
+  // Flavor the workload started on, resolved from its environment against this
+  // runner's reported catalog. Recorded rather than re-resolved so metering
+  // does not move when the environment is repointed or the catalog changes —
+  // the same reason a volume records its storage class. Empty for a workload
+  // started without an environment, which emits no compute usage.
+  string flavor = 26;
   // Machine-readable reason for failures when status is WORKLOAD_STATUS_FAILED.
   // When status is not FAILED, this value may be unset or stale.
   optional WorkloadFailureReason failure_reason = 15;

--- a/proto/agynio/api/runners/v1/runners.proto
+++ b/proto/agynio/api/runners/v1/runners.proto
@@ -438,6 +438,10 @@ message CreateWorkloadRequest {
   optional string agent_class_id = 13;
   // Present when owner_kind is RUNTIME_OWNER_KIND_AGENT_INSTANCE; absent otherwise.
   optional string agent_instance_id = 14;
+  // Flavor this workload is starting on, resolved from its environment. Stored
+  // as given and never re-resolved, so metering keeps billing what the workload
+  // actually started on. Empty for a workload started without an environment.
+  string flavor = 15;
 }
 
 message CreateWorkloadResponse {

--- a/proto/agynio/api/runners/v1/runners.proto
+++ b/proto/agynio/api/runners/v1/runners.proto
@@ -392,11 +392,7 @@ message Workload {
   optional google.protobuf.Timestamp removed_at = 12;
   int32 allocated_cpu_millicores = 13;
   int64 allocated_ram_bytes = 14;
-  // Flavor the workload started on, resolved from its environment against this
-  // runner's reported catalog. Recorded rather than re-resolved so metering
-  // does not move when the environment is repointed or the catalog changes —
-  // the same reason a volume records its storage class. Empty for a workload
-  // started without an environment, which emits no compute usage.
+  // Flavor the workload started on. Empty when it started without an environment.
   string flavor = 26;
   // Machine-readable reason for failures when status is WORKLOAD_STATUS_FAILED.
   // When status is not FAILED, this value may be unset or stale.
@@ -438,9 +434,6 @@ message CreateWorkloadRequest {
   optional string agent_class_id = 13;
   // Present when owner_kind is RUNTIME_OWNER_KIND_AGENT_INSTANCE; absent otherwise.
   optional string agent_instance_id = 14;
-  // Flavor this workload is starting on, resolved from its environment. Stored
-  // as given and never re-resolved, so metering keeps billing what the workload
-  // actually started on. Empty for a workload started without an environment.
   string flavor = 15;
 }
 


### PR DESCRIPTION
Implements the contract half of agynio/architecture#165.

Adds `UNIT_FLAVOR_SECONDS` and `Workload.flavor`.

A flavor is the unit a workload is actually allocated; CPU and memory are two numbers inside it. Billing them separately re-derives a shape the platform already names, in units nobody prices. The existing values are not measurements either — `allocated_cpu_millicores` and `allocated_ram_bytes` are the flavor's own numbers plus sidecar inline resources, and nothing samples real consumption.

The flavor is **recorded** on the workload rather than re-resolved at sampling time, so billing does not move when an environment is repointed or a catalog entry is edited — the same reason a volume already records its `storage_class`. Empty means the workload started without an environment; those emit no compute usage.

Additive: field numbers 5 and 26 were unused. `allocated_cpu_millicores`/`allocated_ram_bytes` stay — they are what the deprecated path still reads, and removing them is a separate change from stopping their use in billing. `buf lint` and `buf breaking` against main are clean.

Follow-ups: `runners` persists the column, `agents-orchestrator` emits the new record and stops emitting CPU/RAM for workloads, `console-app` shows flavor-time.