### PR TITLE
feat(agents): instance_idle_ttl on the agent class

### DIFF
--- a/proto/agynio/api/agents/v1/agents.proto
+++ b/proto/agynio/api/agents/v1/agents.proto
@@ -215,6 +215,11 @@ message Agent {
   // a property of how the agent is written, so it lives on the class rather
   // than the instance. Defaults to DISCARD.
   AgentFinalMessage final_message = 17;
+  // How long an instance may sit idle before the platform pauses it with
+  // pause_reason "idle_ttl_exceeded". Idleness is measured from the instance's
+  // last activity, and a paused instance keeps its thread and its inbox --
+  // ResumeInstance picks up whatever arrived. Empty means never.
+  optional string instance_idle_ttl = 18; // Go duration string (e.g., "30m", "6h").
 }
 
 message CreateAgentRequest {
@@ -236,6 +241,11 @@ message CreateAgentRequest {
   string environment_id = 14; // UUID
   AgentDefaultThread default_thread = 15;
   AgentFinalMessage final_message = 16;
+  // How long an instance may sit idle before the platform pauses it with
+  // pause_reason "idle_ttl_exceeded". Idleness is measured from the instance's
+  // last activity, and a paused instance keeps its thread and its inbox --
+  // ResumeInstance picks up whatever arrived. Empty means never.
+  optional string instance_idle_ttl = 17; // Go duration string (e.g., "30m", "6h").
 }
 
 message CreateAgentResponse {
@@ -280,6 +290,11 @@ message UpdateAgentRequest {
   optional string environment_id = 14; // UUID
   optional AgentDefaultThread default_thread = 15;
   optional AgentFinalMessage final_message = 16;
+  // How long an instance may sit idle before the platform pauses it with
+  // pause_reason "idle_ttl_exceeded". Idleness is measured from the instance's
+  // last activity, and a paused instance keeps its thread and its inbox --
+  // ResumeInstance picks up whatever arrived. Empty means never.
+  optional string instance_idle_ttl = 17; // Go duration string (e.g., "30m", "6h").
 }
 
 message UpdateAgentResponse {


### PR DESCRIPTION
The last unimplemented piece of [`2026-07-14-agent-instances-and-inboxes.md`](https://github.com/agynio/architecture/blob/main/changes/2026-07-14-agent-instances-and-inboxes.md):

> Instance idle GC (background loop that transitions `active → paused` past `instance_idle_ttl` with `pause_reason=idle_ttl_exceeded`) is not implemented.
> `instance_idle_ttl` field does not exist on the Agent resource.

Adds it to `Agent` (18), `CreateAgentRequest` (17) and `UpdateAgentRequest` (17), as a Go duration string like the neighbouring `idle_timeout`.

On the **class**, not the instance: idleness is measured per instance, but the limit is a property of the kind of agent — a long-lived assistant and a one-shot worker want different answers, and every instance of one agent wants the same one.

Distinct from `idle_timeout`, which stops a *workload*. This pauses the *instance*: the thread and inbox survive, and `ResumeInstance` picks up whatever arrived. Empty means never.

`buf lint` and `buf breaking` clean. The GC loop follows in agynio/agents.