### PR TITLE
feat(agents): sender handle on the inbox item

### DIFF
--- a/proto/agynio/api/agents/v1/agents.proto
+++ b/proto/agynio/api/agents/v1/agents.proto
@@ -215,10 +215,6 @@ message Agent {
   // a property of how the agent is written, so it lives on the class rather
   // than the instance. Defaults to DISCARD.
   AgentFinalMessage final_message = 17;
-  // How long an instance may sit idle before the platform pauses it with
-  // pause_reason "idle_ttl_exceeded". Idleness is measured from the instance's
-  // last activity, and a paused instance keeps its thread and its inbox --
-  // ResumeInstance picks up whatever arrived. Empty means never.
   optional string instance_idle_ttl = 18; // Go duration string (e.g., "30m", "6h").
 }
 
@@ -241,10 +237,6 @@ message CreateAgentRequest {
   string environment_id = 14; // UUID
   AgentDefaultThread default_thread = 15;
   AgentFinalMessage final_message = 16;
-  // How long an instance may sit idle before the platform pauses it with
-  // pause_reason "idle_ttl_exceeded". Idleness is measured from the instance's
-  // last activity, and a paused instance keeps its thread and its inbox --
-  // ResumeInstance picks up whatever arrived. Empty means never.
   optional string instance_idle_ttl = 17; // Go duration string (e.g., "30m", "6h").
 }
 
@@ -290,10 +282,6 @@ message UpdateAgentRequest {
   optional string environment_id = 14; // UUID
   optional AgentDefaultThread default_thread = 15;
   optional AgentFinalMessage final_message = 16;
-  // How long an instance may sit idle before the platform pauses it with
-  // pause_reason "idle_ttl_exceeded". Idleness is measured from the instance's
-  // last activity, and a paused instance keeps its thread and its inbox --
-  // ResumeInstance picks up whatever arrived. Empty means never.
   optional string instance_idle_ttl = 17; // Go duration string (e.g., "30m", "6h").
 }
 
@@ -480,6 +468,7 @@ message InboxItem {
   repeated string file_ids = 8; // UUIDs
   google.protobuf.Timestamp accepted_at = 9;
   optional google.protobuf.Timestamp acked_at = 10;
+  optional string sender_handle = 11; // Handle stem without leading @
 }
 
 message WriteInboxItemRequest {


### PR DESCRIPTION
`agynd` prefixes every inbox item with a header naming its source, per [agynd-cli.md §2](https://github.com/agynio/architecture/blob/main/architecture/agynd-cli.md), and the spec calls for `from: @sender-handle`. `InboxItem` carries only `sender_id`.

The reverse lookup exists — `Identity.BatchGetNicknames` — but [identity.md](https://github.com/agynio/architecture/blob/main/architecture/identity.md) makes the Identity service internal by design: nicknames reach external clients through the owner service. An agent workload talks to the Gateway, so it cannot call it, and a raw identity id was all it could show the model.

Resolved by Agents when the item is served, like `thread_id` and `message_id` are denormalised onto it already. Empty when the sender holds no nickname in the org.