### PR TITLE
feat: image catalog and pull proxy; deprecate hooks and image pull secrets

### DIFF
--- a/proto/agynio/api/agents/v1/agents.proto
+++ b/proto/agynio/api/agents/v1/agents.proto
@@ -7,7 +7,7 @@ import "google/protobuf/timestamp.proto";
 option go_package = "github.com/agynio/api/gen/agynio/api/agents/v1;agentsv1";
 
 // AgentsService manages agent resources: agents, volumes, volume attachments,
-// MCP servers, skills, environment variables, and init scripts.
+// MCP servers, skills, hooks, environment variables, and init scripts.
 //
 // This is a control-plane service. It stores desired state;
 // other services reconcile toward it.
@@ -86,6 +86,12 @@ service AgentsService {
   rpc DeleteSkill(DeleteSkillRequest) returns (DeleteSkillResponse);
   rpc ListSkills(ListSkillsRequest) returns (ListSkillsResponse);
 
+  // --- Hooks ---
+  rpc CreateHook(CreateHookRequest) returns (CreateHookResponse) { option deprecated = true; }
+  rpc GetHook(GetHookRequest) returns (GetHookResponse) { option deprecated = true; }
+  rpc UpdateHook(UpdateHookRequest) returns (UpdateHookResponse) { option deprecated = true; }
+  rpc DeleteHook(DeleteHookRequest) returns (DeleteHookResponse) { option deprecated = true; }
+  rpc ListHooks(ListHooksRequest) returns (ListHooksResponse) { option deprecated = true; }
 
   // --- Envs ---
   rpc CreateEnv(CreateEnvRequest) returns (CreateEnvResponse);
@@ -102,6 +108,10 @@ service AgentsService {
   rpc ListInitScripts(ListInitScriptsRequest) returns (ListInitScriptsResponse);
 
   // --- Image Pull Secret Attachments (no Update - immutable) ---
+  rpc CreateImagePullSecretAttachment(CreateImagePullSecretAttachmentRequest) returns (CreateImagePullSecretAttachmentResponse) { option deprecated = true; }
+  rpc GetImagePullSecretAttachment(GetImagePullSecretAttachmentRequest) returns (GetImagePullSecretAttachmentResponse) { option deprecated = true; }
+  rpc DeleteImagePullSecretAttachment(DeleteImagePullSecretAttachmentRequest) returns (DeleteImagePullSecretAttachmentResponse) { option deprecated = true; }
+  rpc ListImagePullSecretAttachments(ListImagePullSecretAttachmentsRequest) returns (ListImagePullSecretAttachmentsResponse) { option deprecated = true; }
 }
 
 // ===========================================================================
@@ -794,6 +804,7 @@ message VolumeAttachment {
   oneof target {
     string agent_id = 3;
     string mcp_id = 4;
+    string hook_id = 5 [deprecated = true];
   }
 }
 
@@ -802,6 +813,7 @@ message CreateVolumeAttachmentRequest {
   oneof target {
     string agent_id = 2;
     string mcp_id = 3;
+    string hook_id = 4 [deprecated = true];
   }
 }
 
@@ -829,10 +841,90 @@ message ListVolumeAttachmentsRequest {
   string volume_id = 3;
   string agent_id = 4;
   string mcp_id = 5;
+  string hook_id = 6 [deprecated = true];
 }
 
 message ListVolumeAttachmentsResponse {
   repeated VolumeAttachment volume_attachments = 1;
+  string next_page_token = 2;
+}
+
+// ===========================================================================
+// Image Pull Secret Attachment
+// ===========================================================================
+
+// Image pull secret attachments are deprecated and no longer served: the
+// agents service returns Unimplemented. A workload's registry credential is
+// minted per workload by the image proxy, which also removes the conflict
+// these had - two attachments carrying different credentials for one registry
+// hostname. Kept here so generated clients still compile; removed in a
+// follow-up.
+
+message ImagePullSecretAttachment {
+  option deprecated = true;
+  EntityMeta meta = 1;
+  string image_pull_secret_id = 2; // UUID
+  oneof target {
+    string agent_id = 3;
+    string mcp_id = 4;
+    string hook_id = 5 [deprecated = true];
+    string environment_id = 6;
+  }
+}
+
+message CreateImagePullSecretAttachmentRequest {
+  option deprecated = true;
+  string image_pull_secret_id = 1; // UUID
+  oneof target {
+    string agent_id = 2;
+    string mcp_id = 3;
+    string hook_id = 4 [deprecated = true];
+    string environment_id = 5;
+  }
+}
+
+message CreateImagePullSecretAttachmentResponse {
+  option deprecated = true;
+  ImagePullSecretAttachment image_pull_secret_attachment = 1;
+}
+
+message GetImagePullSecretAttachmentRequest {
+  option deprecated = true;
+  string id = 1; // UUID
+}
+
+message GetImagePullSecretAttachmentResponse {
+  option deprecated = true;
+  ImagePullSecretAttachment image_pull_secret_attachment = 1;
+}
+
+message DeleteImagePullSecretAttachmentRequest {
+  option deprecated = true;
+  string id = 1; // UUID
+}
+
+message DeleteImagePullSecretAttachmentResponse {
+  option deprecated = true;
+}
+
+message ListImagePullSecretAttachmentsRequest {
+  option deprecated = true;
+  int32 page_size = 1;
+  string page_token = 2;
+  // The organization whose image pull secret attachments are listed. Required
+  // of a caller presenting an identity; the remaining ids only narrow the
+  // result within it.
+  string organization_id = 8; // UUID
+  string image_pull_secret_id = 3;
+  string agent_id = 4;
+  string mcp_id = 5;
+  string hook_id = 6 [deprecated = true];
+  string environment_id = 7;
+}
+
+message ListImagePullSecretAttachmentsResponse {
+  option deprecated = true;
+  repeated ImagePullSecretAttachment image_pull_secret_attachments = 1;
   string next_page_token = 2;
 }
 
@@ -969,6 +1061,88 @@ message ListSkillsResponse {
 }
 
 // ===========================================================================
+// Hook
+// ===========================================================================
+
+// Hooks are deprecated and no longer served: the agents service returns
+// Unimplemented. They are the last resource carrying a free-form image
+// reference, which is what the image catalog exists to remove. Kept here so
+// generated clients still compile; removed in a follow-up.
+
+message Hook {
+  option deprecated = true;
+  EntityMeta meta = 1;
+  string agent_id = 2; // UUID
+  string event = 3;
+  string function = 4;
+  string image = 5;
+  ComputeResources resources = 6;
+  string description = 7;
+}
+
+message CreateHookRequest {
+  option deprecated = true;
+  string agent_id = 1; // UUID
+  string event = 2;
+  string function = 3;
+  string image = 4;
+  ComputeResources resources = 5;
+  string description = 6;
+}
+
+message CreateHookResponse {
+  option deprecated = true;
+  Hook hook = 1;
+}
+
+message GetHookRequest {
+  option deprecated = true;
+  string id = 1; // UUID
+}
+
+message GetHookResponse {
+  option deprecated = true;
+  Hook hook = 1;
+}
+
+message UpdateHookRequest {
+  option deprecated = true;
+  string id = 1; // UUID
+  optional string event = 2;
+  optional string function = 3;
+  optional string image = 4;
+  optional ComputeResources resources = 5;
+  optional string description = 6;
+}
+
+message UpdateHookResponse {
+  option deprecated = true;
+  Hook hook = 1;
+}
+
+message DeleteHookRequest {
+  option deprecated = true;
+  string id = 1; // UUID
+}
+
+message DeleteHookResponse {
+  option deprecated = true;
+}
+
+message ListHooksRequest {
+  option deprecated = true;
+  int32 page_size = 1;
+  string page_token = 2;
+  string agent_id = 3;
+}
+
+message ListHooksResponse {
+  option deprecated = true;
+  repeated Hook hooks = 1;
+  string next_page_token = 2;
+}
+
+// ===========================================================================
 // Env
 // ===========================================================================
 
@@ -979,6 +1153,7 @@ message Env {
   oneof target {
     string agent_id = 4;
     string mcp_id = 5;
+    string hook_id = 6 [deprecated = true];
     string environment_id = 9;
   }
   oneof source {
@@ -993,6 +1168,7 @@ message CreateEnvRequest {
   oneof target {
     string agent_id = 3;
     string mcp_id = 4;
+    string hook_id = 5 [deprecated = true];
     string environment_id = 8;
   }
   oneof source {
@@ -1039,6 +1215,7 @@ message ListEnvsRequest {
   string organization_id = 7; // UUID
   string agent_id = 3;
   string mcp_id = 4;
+  string hook_id = 5 [deprecated = true];
   string environment_id = 6;
 }
 
@@ -1058,6 +1235,7 @@ message InitScript {
   oneof target {
     string agent_id = 4;
     string mcp_id = 5;
+    string hook_id = 6 [deprecated = true];
   }
 }
 
@@ -1067,6 +1245,7 @@ message CreateInitScriptRequest {
   oneof target {
     string agent_id = 3;
     string mcp_id = 4;
+    string hook_id = 5 [deprecated = true];
   }
 }
 
@@ -1103,6 +1282,7 @@ message ListInitScriptsRequest {
   string page_token = 2;
   string agent_id = 3;
   string mcp_id = 4;
+  string hook_id = 5 [deprecated = true];
 }
 
 message ListInitScriptsResponse {

--- a/proto/agynio/api/agents/v1/agents.proto
+++ b/proto/agynio/api/agents/v1/agents.proto
@@ -102,10 +102,6 @@ service AgentsService {
   rpc ListInitScripts(ListInitScriptsRequest) returns (ListInitScriptsResponse);
 
   // --- Image Pull Secret Attachments (no Update - immutable) ---
-  rpc CreateImagePullSecretAttachment(CreateImagePullSecretAttachmentRequest) returns (CreateImagePullSecretAttachmentResponse);
-  rpc GetImagePullSecretAttachment(GetImagePullSecretAttachmentRequest) returns (GetImagePullSecretAttachmentResponse);
-  rpc DeleteImagePullSecretAttachment(DeleteImagePullSecretAttachmentRequest) returns (DeleteImagePullSecretAttachmentResponse);
-  rpc ListImagePullSecretAttachments(ListImagePullSecretAttachmentsRequest) returns (ListImagePullSecretAttachmentsResponse);
 }
 
 // ===========================================================================
@@ -837,65 +833,6 @@ message ListVolumeAttachmentsRequest {
 
 message ListVolumeAttachmentsResponse {
   repeated VolumeAttachment volume_attachments = 1;
-  string next_page_token = 2;
-}
-
-// ===========================================================================
-// Image Pull Secret Attachment
-// ===========================================================================
-
-message ImagePullSecretAttachment {
-  EntityMeta meta = 1;
-  string image_pull_secret_id = 2; // UUID
-  oneof target {
-    string agent_id = 3;
-    string mcp_id = 4;
-    string environment_id = 6;
-  }
-}
-
-message CreateImagePullSecretAttachmentRequest {
-  string image_pull_secret_id = 1; // UUID
-  oneof target {
-    string agent_id = 2;
-    string mcp_id = 3;
-    string environment_id = 5;
-  }
-}
-
-message CreateImagePullSecretAttachmentResponse {
-  ImagePullSecretAttachment image_pull_secret_attachment = 1;
-}
-
-message GetImagePullSecretAttachmentRequest {
-  string id = 1; // UUID
-}
-
-message GetImagePullSecretAttachmentResponse {
-  ImagePullSecretAttachment image_pull_secret_attachment = 1;
-}
-
-message DeleteImagePullSecretAttachmentRequest {
-  string id = 1; // UUID
-}
-
-message DeleteImagePullSecretAttachmentResponse {}
-
-message ListImagePullSecretAttachmentsRequest {
-  int32 page_size = 1;
-  string page_token = 2;
-  // The organization whose image pull secret attachments are listed. Required
-  // of a caller presenting an identity; the remaining ids only narrow the
-  // result within it.
-  string organization_id = 8; // UUID
-  string image_pull_secret_id = 3;
-  string agent_id = 4;
-  string mcp_id = 5;
-  string environment_id = 7;
-}
-
-message ListImagePullSecretAttachmentsResponse {
-  repeated ImagePullSecretAttachment image_pull_secret_attachments = 1;
   string next_page_token = 2;
 }
 

--- a/proto/agynio/api/agents/v1/agents.proto
+++ b/proto/agynio/api/agents/v1/agents.proto
@@ -7,7 +7,7 @@ import "google/protobuf/timestamp.proto";
 option go_package = "github.com/agynio/api/gen/agynio/api/agents/v1;agentsv1";
 
 // AgentsService manages agent resources: agents, volumes, volume attachments,
-// MCP servers, skills, hooks, environment variables, and init scripts.
+// MCP servers, skills, environment variables, and init scripts.
 //
 // This is a control-plane service. It stores desired state;
 // other services reconcile toward it.
@@ -86,12 +86,6 @@ service AgentsService {
   rpc DeleteSkill(DeleteSkillRequest) returns (DeleteSkillResponse);
   rpc ListSkills(ListSkillsRequest) returns (ListSkillsResponse);
 
-  // --- Hooks ---
-  rpc CreateHook(CreateHookRequest) returns (CreateHookResponse);
-  rpc GetHook(GetHookRequest) returns (GetHookResponse);
-  rpc UpdateHook(UpdateHookRequest) returns (UpdateHookResponse);
-  rpc DeleteHook(DeleteHookRequest) returns (DeleteHookResponse);
-  rpc ListHooks(ListHooksRequest) returns (ListHooksResponse);
 
   // --- Envs ---
   rpc CreateEnv(CreateEnvRequest) returns (CreateEnvResponse);
@@ -804,7 +798,6 @@ message VolumeAttachment {
   oneof target {
     string agent_id = 3;
     string mcp_id = 4;
-    string hook_id = 5;
   }
 }
 
@@ -813,7 +806,6 @@ message CreateVolumeAttachmentRequest {
   oneof target {
     string agent_id = 2;
     string mcp_id = 3;
-    string hook_id = 4;
   }
 }
 
@@ -841,7 +833,6 @@ message ListVolumeAttachmentsRequest {
   string volume_id = 3;
   string agent_id = 4;
   string mcp_id = 5;
-  string hook_id = 6;
 }
 
 message ListVolumeAttachmentsResponse {
@@ -859,7 +850,6 @@ message ImagePullSecretAttachment {
   oneof target {
     string agent_id = 3;
     string mcp_id = 4;
-    string hook_id = 5;
     string environment_id = 6;
   }
 }
@@ -869,7 +859,6 @@ message CreateImagePullSecretAttachmentRequest {
   oneof target {
     string agent_id = 2;
     string mcp_id = 3;
-    string hook_id = 4;
     string environment_id = 5;
   }
 }
@@ -902,7 +891,6 @@ message ListImagePullSecretAttachmentsRequest {
   string image_pull_secret_id = 3;
   string agent_id = 4;
   string mcp_id = 5;
-  string hook_id = 6;
   string environment_id = 7;
 }
 
@@ -1044,71 +1032,6 @@ message ListSkillsResponse {
 }
 
 // ===========================================================================
-// Hook
-// ===========================================================================
-
-message Hook {
-  EntityMeta meta = 1;
-  string agent_id = 2; // UUID
-  string event = 3;
-  string function = 4;
-  string image = 5;
-  ComputeResources resources = 6;
-  string description = 7;
-}
-
-message CreateHookRequest {
-  string agent_id = 1; // UUID
-  string event = 2;
-  string function = 3;
-  string image = 4;
-  ComputeResources resources = 5;
-  string description = 6;
-}
-
-message CreateHookResponse {
-  Hook hook = 1;
-}
-
-message GetHookRequest {
-  string id = 1; // UUID
-}
-
-message GetHookResponse {
-  Hook hook = 1;
-}
-
-message UpdateHookRequest {
-  string id = 1; // UUID
-  optional string event = 2;
-  optional string function = 3;
-  optional string image = 4;
-  optional ComputeResources resources = 5;
-  optional string description = 6;
-}
-
-message UpdateHookResponse {
-  Hook hook = 1;
-}
-
-message DeleteHookRequest {
-  string id = 1; // UUID
-}
-
-message DeleteHookResponse {}
-
-message ListHooksRequest {
-  int32 page_size = 1;
-  string page_token = 2;
-  string agent_id = 3;
-}
-
-message ListHooksResponse {
-  repeated Hook hooks = 1;
-  string next_page_token = 2;
-}
-
-// ===========================================================================
 // Env
 // ===========================================================================
 
@@ -1119,7 +1042,6 @@ message Env {
   oneof target {
     string agent_id = 4;
     string mcp_id = 5;
-    string hook_id = 6;
     string environment_id = 9;
   }
   oneof source {
@@ -1134,7 +1056,6 @@ message CreateEnvRequest {
   oneof target {
     string agent_id = 3;
     string mcp_id = 4;
-    string hook_id = 5;
     string environment_id = 8;
   }
   oneof source {
@@ -1181,7 +1102,6 @@ message ListEnvsRequest {
   string organization_id = 7; // UUID
   string agent_id = 3;
   string mcp_id = 4;
-  string hook_id = 5;
   string environment_id = 6;
 }
 
@@ -1201,7 +1121,6 @@ message InitScript {
   oneof target {
     string agent_id = 4;
     string mcp_id = 5;
-    string hook_id = 6;
   }
 }
 
@@ -1211,7 +1130,6 @@ message CreateInitScriptRequest {
   oneof target {
     string agent_id = 3;
     string mcp_id = 4;
-    string hook_id = 5;
   }
 }
 
@@ -1248,7 +1166,6 @@ message ListInitScriptsRequest {
   string page_token = 2;
   string agent_id = 3;
   string mcp_id = 4;
-  string hook_id = 5;
 }
 
 message ListInitScriptsResponse {

--- a/proto/agynio/api/agents/v1/agents.proto
+++ b/proto/agynio/api/agents/v1/agents.proto
@@ -87,11 +87,21 @@ service AgentsService {
   rpc ListSkills(ListSkillsRequest) returns (ListSkillsResponse);
 
   // --- Hooks ---
-  rpc CreateHook(CreateHookRequest) returns (CreateHookResponse) { option deprecated = true; }
-  rpc GetHook(GetHookRequest) returns (GetHookResponse) { option deprecated = true; }
-  rpc UpdateHook(UpdateHookRequest) returns (UpdateHookResponse) { option deprecated = true; }
-  rpc DeleteHook(DeleteHookRequest) returns (DeleteHookResponse) { option deprecated = true; }
-  rpc ListHooks(ListHooksRequest) returns (ListHooksResponse) { option deprecated = true; }
+  rpc CreateHook(CreateHookRequest) returns (CreateHookResponse) {
+    option deprecated = true;
+  }
+  rpc GetHook(GetHookRequest) returns (GetHookResponse) {
+    option deprecated = true;
+  }
+  rpc UpdateHook(UpdateHookRequest) returns (UpdateHookResponse) {
+    option deprecated = true;
+  }
+  rpc DeleteHook(DeleteHookRequest) returns (DeleteHookResponse) {
+    option deprecated = true;
+  }
+  rpc ListHooks(ListHooksRequest) returns (ListHooksResponse) {
+    option deprecated = true;
+  }
 
   // --- Envs ---
   rpc CreateEnv(CreateEnvRequest) returns (CreateEnvResponse);
@@ -108,10 +118,18 @@ service AgentsService {
   rpc ListInitScripts(ListInitScriptsRequest) returns (ListInitScriptsResponse);
 
   // --- Image Pull Secret Attachments (no Update - immutable) ---
-  rpc CreateImagePullSecretAttachment(CreateImagePullSecretAttachmentRequest) returns (CreateImagePullSecretAttachmentResponse) { option deprecated = true; }
-  rpc GetImagePullSecretAttachment(GetImagePullSecretAttachmentRequest) returns (GetImagePullSecretAttachmentResponse) { option deprecated = true; }
-  rpc DeleteImagePullSecretAttachment(DeleteImagePullSecretAttachmentRequest) returns (DeleteImagePullSecretAttachmentResponse) { option deprecated = true; }
-  rpc ListImagePullSecretAttachments(ListImagePullSecretAttachmentsRequest) returns (ListImagePullSecretAttachmentsResponse) { option deprecated = true; }
+  rpc CreateImagePullSecretAttachment(CreateImagePullSecretAttachmentRequest) returns (CreateImagePullSecretAttachmentResponse) {
+    option deprecated = true;
+  }
+  rpc GetImagePullSecretAttachment(GetImagePullSecretAttachmentRequest) returns (GetImagePullSecretAttachmentResponse) {
+    option deprecated = true;
+  }
+  rpc DeleteImagePullSecretAttachment(DeleteImagePullSecretAttachmentRequest) returns (DeleteImagePullSecretAttachmentResponse) {
+    option deprecated = true;
+  }
+  rpc ListImagePullSecretAttachments(ListImagePullSecretAttachmentsRequest) returns (ListImagePullSecretAttachmentsResponse) {
+    option deprecated = true;
+  }
 }
 
 // ===========================================================================

--- a/proto/agynio/api/agents/v1/agents.proto
+++ b/proto/agynio/api/agents/v1/agents.proto
@@ -535,7 +535,9 @@ message Environment {
   // Superseded by runner_id + flavor: placement is now environment to runner
   // directly, with the flavor named within that runner's catalog.
   string flavor_id = 4 [deprecated = true];
-  string image = 5;
+  // Superseded by workspace_image_id + workspace_image_tag: an environment
+  // names catalog records rather than holding a registry address.
+  string image = 5 [deprecated = true];
   string flavor_name = 6 [deprecated = true];
   // The runner this environment places workloads on.
   string runner_id = 7;
@@ -544,15 +546,29 @@ message Environment {
   // Deliberately not validated here: platform resources and runner
   // configuration may be applied in either order.
   string flavor = 8;
+  // The image the workload's main container runs. Must be a visible Image of
+  // type workspace; the tag must be one discovery has seen. Validated on
+  // write and resolved again at each workload start.
+  string workspace_image_id = 9; // UUID
+  string workspace_image_tag = 10;
+  // The image supplying the agent CLI, injected as an init container. Empty
+  // means a workspace-only environment: usable by sandboxes, rejected by
+  // CreateAgent.
+  string agent_runtime_image_id = 11; // UUID
+  string agent_runtime_image_tag = 12;
 }
 
 message CreateEnvironmentRequest {
   string organization_id = 1;
   string name = 2;
   string flavor_id = 3 [deprecated = true];
-  string image = 4;
+  string image = 4 [deprecated = true];
   string runner_id = 5;
   string flavor = 6;
+  string workspace_image_id = 7; // UUID
+  string workspace_image_tag = 8;
+  string agent_runtime_image_id = 9; // UUID
+  string agent_runtime_image_tag = 10;
 }
 
 message CreateEnvironmentResponse {
@@ -571,9 +587,14 @@ message UpdateEnvironmentRequest {
   string id = 1; // UUID
   optional string name = 2;
   optional string flavor_id = 3 [deprecated = true];
-  optional string image = 4;
+  optional string image = 4 [deprecated = true];
   optional string runner_id = 5;
   optional string flavor = 6;
+  optional string workspace_image_id = 7; // UUID
+  optional string workspace_image_tag = 8;
+  // Clearing both makes the environment workspace-only.
+  optional string agent_runtime_image_id = 9; // UUID
+  optional string agent_runtime_image_tag = 10;
 }
 
 message UpdateEnvironmentResponse {
@@ -897,20 +918,27 @@ message ListImagePullSecretAttachmentsResponse {
 message Mcp {
   EntityMeta meta = 1;
   string agent_id = 2; // UUID
-  string image = 3;
+  // Superseded by image_id + image_tag.
+  string image = 3 [deprecated = true];
   string command = 4;
   ComputeResources resources = 5;
   string description = 6;
   string name = 7; // MCP server name, unique within agent
+  // An Image of type mcp or workspace: a purpose-built server and a
+  // devcontainer are both legitimate ways to host one.
+  string image_id = 8; // UUID
+  string image_tag = 9;
 }
 
 message CreateMcpRequest {
   string agent_id = 1; // UUID
-  string image = 2;
+  string image = 2 [deprecated = true];
   string command = 3;
   ComputeResources resources = 4;
   string description = 5;
   string name = 6; // MCP server name
+  string image_id = 7; // UUID
+  string image_tag = 8;
 }
 
 message CreateMcpResponse {
@@ -927,10 +955,12 @@ message GetMcpResponse {
 
 message UpdateMcpRequest {
   string id = 1; // UUID
-  optional string image = 2;
+  optional string image = 2 [deprecated = true];
   optional string command = 3;
   optional ComputeResources resources = 4;
   optional string description = 5;
+  optional string image_id = 6; // UUID
+  optional string image_tag = 7;
 }
 
 message UpdateMcpResponse {

--- a/proto/agynio/api/gateway/v1/agents.proto
+++ b/proto/agynio/api/gateway/v1/agents.proto
@@ -74,6 +74,12 @@ service AgentsGateway {
   rpc DeleteSkill(agynio.api.agents.v1.DeleteSkillRequest) returns (agynio.api.agents.v1.DeleteSkillResponse);
   rpc ListSkills(agynio.api.agents.v1.ListSkillsRequest) returns (agynio.api.agents.v1.ListSkillsResponse);
 
+  // --- Hooks ---
+  rpc CreateHook(agynio.api.agents.v1.CreateHookRequest) returns (agynio.api.agents.v1.CreateHookResponse) { option deprecated = true; }
+  rpc GetHook(agynio.api.agents.v1.GetHookRequest) returns (agynio.api.agents.v1.GetHookResponse) { option deprecated = true; }
+  rpc UpdateHook(agynio.api.agents.v1.UpdateHookRequest) returns (agynio.api.agents.v1.UpdateHookResponse) { option deprecated = true; }
+  rpc DeleteHook(agynio.api.agents.v1.DeleteHookRequest) returns (agynio.api.agents.v1.DeleteHookResponse) { option deprecated = true; }
+  rpc ListHooks(agynio.api.agents.v1.ListHooksRequest) returns (agynio.api.agents.v1.ListHooksResponse) { option deprecated = true; }
 
   // --- Envs ---
   rpc CreateEnv(agynio.api.agents.v1.CreateEnvRequest) returns (agynio.api.agents.v1.CreateEnvResponse);
@@ -89,4 +95,9 @@ service AgentsGateway {
   rpc DeleteInitScript(agynio.api.agents.v1.DeleteInitScriptRequest) returns (agynio.api.agents.v1.DeleteInitScriptResponse);
   rpc ListInitScripts(agynio.api.agents.v1.ListInitScriptsRequest) returns (agynio.api.agents.v1.ListInitScriptsResponse);
 
+  // --- Image Pull Secret Attachments (no Update - immutable) ---
+  rpc CreateImagePullSecretAttachment(agynio.api.agents.v1.CreateImagePullSecretAttachmentRequest) returns (agynio.api.agents.v1.CreateImagePullSecretAttachmentResponse) { option deprecated = true; }
+  rpc GetImagePullSecretAttachment(agynio.api.agents.v1.GetImagePullSecretAttachmentRequest) returns (agynio.api.agents.v1.GetImagePullSecretAttachmentResponse) { option deprecated = true; }
+  rpc DeleteImagePullSecretAttachment(agynio.api.agents.v1.DeleteImagePullSecretAttachmentRequest) returns (agynio.api.agents.v1.DeleteImagePullSecretAttachmentResponse) { option deprecated = true; }
+  rpc ListImagePullSecretAttachments(agynio.api.agents.v1.ListImagePullSecretAttachmentsRequest) returns (agynio.api.agents.v1.ListImagePullSecretAttachmentsResponse) { option deprecated = true; }
 }

--- a/proto/agynio/api/gateway/v1/agents.proto
+++ b/proto/agynio/api/gateway/v1/agents.proto
@@ -75,11 +75,21 @@ service AgentsGateway {
   rpc ListSkills(agynio.api.agents.v1.ListSkillsRequest) returns (agynio.api.agents.v1.ListSkillsResponse);
 
   // --- Hooks ---
-  rpc CreateHook(agynio.api.agents.v1.CreateHookRequest) returns (agynio.api.agents.v1.CreateHookResponse) { option deprecated = true; }
-  rpc GetHook(agynio.api.agents.v1.GetHookRequest) returns (agynio.api.agents.v1.GetHookResponse) { option deprecated = true; }
-  rpc UpdateHook(agynio.api.agents.v1.UpdateHookRequest) returns (agynio.api.agents.v1.UpdateHookResponse) { option deprecated = true; }
-  rpc DeleteHook(agynio.api.agents.v1.DeleteHookRequest) returns (agynio.api.agents.v1.DeleteHookResponse) { option deprecated = true; }
-  rpc ListHooks(agynio.api.agents.v1.ListHooksRequest) returns (agynio.api.agents.v1.ListHooksResponse) { option deprecated = true; }
+  rpc CreateHook(agynio.api.agents.v1.CreateHookRequest) returns (agynio.api.agents.v1.CreateHookResponse) {
+    option deprecated = true;
+  }
+  rpc GetHook(agynio.api.agents.v1.GetHookRequest) returns (agynio.api.agents.v1.GetHookResponse) {
+    option deprecated = true;
+  }
+  rpc UpdateHook(agynio.api.agents.v1.UpdateHookRequest) returns (agynio.api.agents.v1.UpdateHookResponse) {
+    option deprecated = true;
+  }
+  rpc DeleteHook(agynio.api.agents.v1.DeleteHookRequest) returns (agynio.api.agents.v1.DeleteHookResponse) {
+    option deprecated = true;
+  }
+  rpc ListHooks(agynio.api.agents.v1.ListHooksRequest) returns (agynio.api.agents.v1.ListHooksResponse) {
+    option deprecated = true;
+  }
 
   // --- Envs ---
   rpc CreateEnv(agynio.api.agents.v1.CreateEnvRequest) returns (agynio.api.agents.v1.CreateEnvResponse);
@@ -96,8 +106,16 @@ service AgentsGateway {
   rpc ListInitScripts(agynio.api.agents.v1.ListInitScriptsRequest) returns (agynio.api.agents.v1.ListInitScriptsResponse);
 
   // --- Image Pull Secret Attachments (no Update - immutable) ---
-  rpc CreateImagePullSecretAttachment(agynio.api.agents.v1.CreateImagePullSecretAttachmentRequest) returns (agynio.api.agents.v1.CreateImagePullSecretAttachmentResponse) { option deprecated = true; }
-  rpc GetImagePullSecretAttachment(agynio.api.agents.v1.GetImagePullSecretAttachmentRequest) returns (agynio.api.agents.v1.GetImagePullSecretAttachmentResponse) { option deprecated = true; }
-  rpc DeleteImagePullSecretAttachment(agynio.api.agents.v1.DeleteImagePullSecretAttachmentRequest) returns (agynio.api.agents.v1.DeleteImagePullSecretAttachmentResponse) { option deprecated = true; }
-  rpc ListImagePullSecretAttachments(agynio.api.agents.v1.ListImagePullSecretAttachmentsRequest) returns (agynio.api.agents.v1.ListImagePullSecretAttachmentsResponse) { option deprecated = true; }
+  rpc CreateImagePullSecretAttachment(agynio.api.agents.v1.CreateImagePullSecretAttachmentRequest) returns (agynio.api.agents.v1.CreateImagePullSecretAttachmentResponse) {
+    option deprecated = true;
+  }
+  rpc GetImagePullSecretAttachment(agynio.api.agents.v1.GetImagePullSecretAttachmentRequest) returns (agynio.api.agents.v1.GetImagePullSecretAttachmentResponse) {
+    option deprecated = true;
+  }
+  rpc DeleteImagePullSecretAttachment(agynio.api.agents.v1.DeleteImagePullSecretAttachmentRequest) returns (agynio.api.agents.v1.DeleteImagePullSecretAttachmentResponse) {
+    option deprecated = true;
+  }
+  rpc ListImagePullSecretAttachments(agynio.api.agents.v1.ListImagePullSecretAttachmentsRequest) returns (agynio.api.agents.v1.ListImagePullSecretAttachmentsResponse) {
+    option deprecated = true;
+  }
 }

--- a/proto/agynio/api/gateway/v1/agents.proto
+++ b/proto/agynio/api/gateway/v1/agents.proto
@@ -89,9 +89,4 @@ service AgentsGateway {
   rpc DeleteInitScript(agynio.api.agents.v1.DeleteInitScriptRequest) returns (agynio.api.agents.v1.DeleteInitScriptResponse);
   rpc ListInitScripts(agynio.api.agents.v1.ListInitScriptsRequest) returns (agynio.api.agents.v1.ListInitScriptsResponse);
 
-  // --- Image Pull Secret Attachments (no Update - immutable) ---
-  rpc CreateImagePullSecretAttachment(agynio.api.agents.v1.CreateImagePullSecretAttachmentRequest) returns (agynio.api.agents.v1.CreateImagePullSecretAttachmentResponse);
-  rpc GetImagePullSecretAttachment(agynio.api.agents.v1.GetImagePullSecretAttachmentRequest) returns (agynio.api.agents.v1.GetImagePullSecretAttachmentResponse);
-  rpc DeleteImagePullSecretAttachment(agynio.api.agents.v1.DeleteImagePullSecretAttachmentRequest) returns (agynio.api.agents.v1.DeleteImagePullSecretAttachmentResponse);
-  rpc ListImagePullSecretAttachments(agynio.api.agents.v1.ListImagePullSecretAttachmentsRequest) returns (agynio.api.agents.v1.ListImagePullSecretAttachmentsResponse);
 }

--- a/proto/agynio/api/gateway/v1/agents.proto
+++ b/proto/agynio/api/gateway/v1/agents.proto
@@ -74,12 +74,6 @@ service AgentsGateway {
   rpc DeleteSkill(agynio.api.agents.v1.DeleteSkillRequest) returns (agynio.api.agents.v1.DeleteSkillResponse);
   rpc ListSkills(agynio.api.agents.v1.ListSkillsRequest) returns (agynio.api.agents.v1.ListSkillsResponse);
 
-  // --- Hooks ---
-  rpc CreateHook(agynio.api.agents.v1.CreateHookRequest) returns (agynio.api.agents.v1.CreateHookResponse);
-  rpc GetHook(agynio.api.agents.v1.GetHookRequest) returns (agynio.api.agents.v1.GetHookResponse);
-  rpc UpdateHook(agynio.api.agents.v1.UpdateHookRequest) returns (agynio.api.agents.v1.UpdateHookResponse);
-  rpc DeleteHook(agynio.api.agents.v1.DeleteHookRequest) returns (agynio.api.agents.v1.DeleteHookResponse);
-  rpc ListHooks(agynio.api.agents.v1.ListHooksRequest) returns (agynio.api.agents.v1.ListHooksResponse);
 
   // --- Envs ---
   rpc CreateEnv(agynio.api.agents.v1.CreateEnvRequest) returns (agynio.api.agents.v1.CreateEnvResponse);

--- a/proto/agynio/api/gateway/v1/images.proto
+++ b/proto/agynio/api/gateway/v1/images.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+
+package agynio.api.gateway.v1;
+
+import "agynio/api/images/v1/images.proto";
+
+option go_package = "github.com/agynio/api/gen/agynio/api/gateway/v1;gatewayv1";
+
+// ResolveVersion and RegisterPlatformImage are deliberately absent: both are
+// internal, and the Gateway is the external surface.
+service ImagesGateway {
+  // --- Images ---
+  rpc CreateImage(agynio.api.images.v1.CreateImageRequest) returns (agynio.api.images.v1.CreateImageResponse);
+  rpc GetImage(agynio.api.images.v1.GetImageRequest) returns (agynio.api.images.v1.GetImageResponse);
+  rpc UpdateImage(agynio.api.images.v1.UpdateImageRequest) returns (agynio.api.images.v1.UpdateImageResponse);
+  rpc DeleteImage(agynio.api.images.v1.DeleteImageRequest) returns (agynio.api.images.v1.DeleteImageResponse);
+  rpc ListImages(agynio.api.images.v1.ListImagesRequest) returns (agynio.api.images.v1.ListImagesResponse);
+
+  // --- Versions ---
+  rpc ListVersions(agynio.api.images.v1.ListVersionsRequest) returns (agynio.api.images.v1.ListVersionsResponse);
+  rpc RefreshImage(agynio.api.images.v1.RefreshImageRequest) returns (agynio.api.images.v1.RefreshImageResponse);
+}

--- a/proto/agynio/api/gateway/v1/secrets.proto
+++ b/proto/agynio/api/gateway/v1/secrets.proto
@@ -24,4 +24,11 @@ service SecretsGateway {
   // --- Resolution ---
   rpc ResolveSecret(agynio.api.secrets.v1.ResolveSecretRequest) returns (agynio.api.secrets.v1.ResolveSecretResponse);
 
+  // --- Image Pull Secrets ---
+  rpc CreateImagePullSecret(agynio.api.secrets.v1.CreateImagePullSecretRequest) returns (agynio.api.secrets.v1.CreateImagePullSecretResponse) { option deprecated = true; }
+  rpc GetImagePullSecret(agynio.api.secrets.v1.GetImagePullSecretRequest) returns (agynio.api.secrets.v1.GetImagePullSecretResponse) { option deprecated = true; }
+  rpc UpdateImagePullSecret(agynio.api.secrets.v1.UpdateImagePullSecretRequest) returns (agynio.api.secrets.v1.UpdateImagePullSecretResponse) { option deprecated = true; }
+  rpc DeleteImagePullSecret(agynio.api.secrets.v1.DeleteImagePullSecretRequest) returns (agynio.api.secrets.v1.DeleteImagePullSecretResponse) { option deprecated = true; }
+  rpc ListImagePullSecrets(agynio.api.secrets.v1.ListImagePullSecretsRequest) returns (agynio.api.secrets.v1.ListImagePullSecretsResponse) { option deprecated = true; }
+  rpc ResolveImagePullSecret(agynio.api.secrets.v1.ResolveImagePullSecretRequest) returns (agynio.api.secrets.v1.ResolveImagePullSecretResponse) { option deprecated = true; }
 }

--- a/proto/agynio/api/gateway/v1/secrets.proto
+++ b/proto/agynio/api/gateway/v1/secrets.proto
@@ -25,10 +25,22 @@ service SecretsGateway {
   rpc ResolveSecret(agynio.api.secrets.v1.ResolveSecretRequest) returns (agynio.api.secrets.v1.ResolveSecretResponse);
 
   // --- Image Pull Secrets ---
-  rpc CreateImagePullSecret(agynio.api.secrets.v1.CreateImagePullSecretRequest) returns (agynio.api.secrets.v1.CreateImagePullSecretResponse) { option deprecated = true; }
-  rpc GetImagePullSecret(agynio.api.secrets.v1.GetImagePullSecretRequest) returns (agynio.api.secrets.v1.GetImagePullSecretResponse) { option deprecated = true; }
-  rpc UpdateImagePullSecret(agynio.api.secrets.v1.UpdateImagePullSecretRequest) returns (agynio.api.secrets.v1.UpdateImagePullSecretResponse) { option deprecated = true; }
-  rpc DeleteImagePullSecret(agynio.api.secrets.v1.DeleteImagePullSecretRequest) returns (agynio.api.secrets.v1.DeleteImagePullSecretResponse) { option deprecated = true; }
-  rpc ListImagePullSecrets(agynio.api.secrets.v1.ListImagePullSecretsRequest) returns (agynio.api.secrets.v1.ListImagePullSecretsResponse) { option deprecated = true; }
-  rpc ResolveImagePullSecret(agynio.api.secrets.v1.ResolveImagePullSecretRequest) returns (agynio.api.secrets.v1.ResolveImagePullSecretResponse) { option deprecated = true; }
+  rpc CreateImagePullSecret(agynio.api.secrets.v1.CreateImagePullSecretRequest) returns (agynio.api.secrets.v1.CreateImagePullSecretResponse) {
+    option deprecated = true;
+  }
+  rpc GetImagePullSecret(agynio.api.secrets.v1.GetImagePullSecretRequest) returns (agynio.api.secrets.v1.GetImagePullSecretResponse) {
+    option deprecated = true;
+  }
+  rpc UpdateImagePullSecret(agynio.api.secrets.v1.UpdateImagePullSecretRequest) returns (agynio.api.secrets.v1.UpdateImagePullSecretResponse) {
+    option deprecated = true;
+  }
+  rpc DeleteImagePullSecret(agynio.api.secrets.v1.DeleteImagePullSecretRequest) returns (agynio.api.secrets.v1.DeleteImagePullSecretResponse) {
+    option deprecated = true;
+  }
+  rpc ListImagePullSecrets(agynio.api.secrets.v1.ListImagePullSecretsRequest) returns (agynio.api.secrets.v1.ListImagePullSecretsResponse) {
+    option deprecated = true;
+  }
+  rpc ResolveImagePullSecret(agynio.api.secrets.v1.ResolveImagePullSecretRequest) returns (agynio.api.secrets.v1.ResolveImagePullSecretResponse) {
+    option deprecated = true;
+  }
 }

--- a/proto/agynio/api/gateway/v1/secrets.proto
+++ b/proto/agynio/api/gateway/v1/secrets.proto
@@ -24,11 +24,4 @@ service SecretsGateway {
   // --- Resolution ---
   rpc ResolveSecret(agynio.api.secrets.v1.ResolveSecretRequest) returns (agynio.api.secrets.v1.ResolveSecretResponse);
 
-  // --- Image Pull Secrets ---
-  rpc CreateImagePullSecret(agynio.api.secrets.v1.CreateImagePullSecretRequest) returns (agynio.api.secrets.v1.CreateImagePullSecretResponse);
-  rpc GetImagePullSecret(agynio.api.secrets.v1.GetImagePullSecretRequest) returns (agynio.api.secrets.v1.GetImagePullSecretResponse);
-  rpc UpdateImagePullSecret(agynio.api.secrets.v1.UpdateImagePullSecretRequest) returns (agynio.api.secrets.v1.UpdateImagePullSecretResponse);
-  rpc DeleteImagePullSecret(agynio.api.secrets.v1.DeleteImagePullSecretRequest) returns (agynio.api.secrets.v1.DeleteImagePullSecretResponse);
-  rpc ListImagePullSecrets(agynio.api.secrets.v1.ListImagePullSecretsRequest) returns (agynio.api.secrets.v1.ListImagePullSecretsResponse);
-  rpc ResolveImagePullSecret(agynio.api.secrets.v1.ResolveImagePullSecretRequest) returns (agynio.api.secrets.v1.ResolveImagePullSecretResponse);
 }

--- a/proto/agynio/api/image_proxy/v1/image_proxy.proto
+++ b/proto/agynio/api/image_proxy/v1/image_proxy.proto
@@ -1,0 +1,54 @@
+syntax = "proto3";
+
+package agynio.api.image_proxy.v1;
+
+import "google/protobuf/timestamp.proto";
+
+option go_package = "github.com/agynio/api/gen/agynio/api/image_proxy/v1;imageproxyv1";
+
+// ImageProxyService is the credential lifecycle behind the image proxy. The
+// pull surface itself is OCI Distribution over HTTPS, not gRPC.
+//
+// Every image reference in a workload spec is rewritten to the proxy, which
+// authenticates upstream using the credential stored on the Image record. That
+// is what keeps registry credentials inside the platform: handing them to a
+// runner would mean writing an organization registry password into the cluster
+// its workloads run in.
+service ImageProxyService {
+  // Issue a credential scoped to one workload and the images it may pull.
+  // Called at workload spec assembly.
+  rpc MintPullCredential(MintPullCredentialRequest) returns (MintPullCredentialResponse);
+  // Revoke a workload's credential. Called on workload stop, alongside the
+  // OpenZiti identity delete. A missed revocation is bounded by the TTL.
+  rpc RevokePullCredential(RevokePullCredentialRequest) returns (RevokePullCredentialResponse);
+}
+
+message MintPullCredentialRequest {
+  string workload_id = 1; // UUID
+  // Images this workload may pull. A pod pulling a workspace image, an agent
+  // runtime and several MCP sidecars issues several requests with the same
+  // credential; the request path identifies which image.
+  repeated string image_ids = 2;
+  // Optional. The organization the workload runs in, so visibility is enforced
+  // on every pull rather than only at assembly.
+  string organization_id = 3;
+}
+
+message MintPullCredentialResponse {
+  string username = 1;
+  // Generated password, returned once. Only its hash is stored.
+  string password = 2;
+  // TTL backstop, so a credential minted for a workload that never started
+  // cannot outlive it.
+  google.protobuf.Timestamp expires_at = 3;
+}
+
+message RevokePullCredentialRequest {
+  string workload_id = 1; // UUID
+}
+
+message RevokePullCredentialResponse {
+  // False when no credential was outstanding, which makes revocation safe to
+  // repeat.
+  bool revoked = 1;
+}

--- a/proto/agynio/api/images/v1/images.proto
+++ b/proto/agynio/api/images/v1/images.proto
@@ -35,6 +35,10 @@ service ImagesService {
   // serve a pull. Internal only - restricted by Istio, not by an identity
   // check.
   rpc ResolveVersion(ResolveVersionRequest) returns (ResolveVersionResponse);
+  // Resolve a reference to an upstream repository and credential without
+  // naming a tag. A blob request carries a digest and no tag, so the Image
+  // Proxy cannot use ResolveVersion for it. Internal only.
+  rpc ResolveImage(ResolveImageRequest) returns (ResolveImageResponse);
   // Create an image if no image of that name exists in the organization, and
   // return the existing one otherwise. Never updates, so re-running an upgrade
   // cannot overwrite a change someone made by hand. Internal only.
@@ -251,6 +255,24 @@ message ResolveVersionResponse {
   // repositories.
   string username = 5;
   string password = 6;
+}
+
+message ResolveImageRequest {
+  oneof reference {
+    string image_id = 1; // UUID
+    ImageRef ref = 2;
+  }
+  // Optional. When set, visibility is enforced against this organization.
+  string consumer_organization_id = 3;
+}
+
+message ResolveImageResponse {
+  Image image = 1;
+  string repository = 2;
+  // Registry credential for the repository. Empty for anonymously readable
+  // repositories.
+  string username = 3;
+  string password = 4;
 }
 
 message RegisterPlatformImageRequest {

--- a/proto/agynio/api/images/v1/images.proto
+++ b/proto/agynio/api/images/v1/images.proto
@@ -1,0 +1,273 @@
+syntax = "proto3";
+
+package agynio.api.images.v1;
+
+import "google/protobuf/timestamp.proto";
+
+option go_package = "github.com/agynio/api/gen/agynio/api/images/v1;imagesv1";
+
+// ImagesService owns the image catalog: the Image records an organization
+// authors, and the Version records the platform discovers by reading upstream
+// repositories.
+//
+// It is the only service in the platform that stores a registry URL or a
+// registry credential. Versions are discovered, never authored - there is no
+// create, update, or delete RPC for them.
+service ImagesService {
+  // --- Images ---
+  rpc CreateImage(CreateImageRequest) returns (CreateImageResponse);
+  rpc GetImage(GetImageRequest) returns (GetImageResponse);
+  rpc UpdateImage(UpdateImageRequest) returns (UpdateImageResponse);
+  rpc DeleteImage(DeleteImageRequest) returns (DeleteImageResponse);
+  rpc ListImages(ListImagesRequest) returns (ListImagesResponse);
+
+  // --- Versions ---
+  // List discovered versions, newest first. Serves stored rows - never blocks
+  // on the upstream registry.
+  rpc ListVersions(ListVersionsRequest) returns (ListVersionsResponse);
+  // Trigger an immediate discovery pass, so a freshly pushed tag appears
+  // without waiting for the poll interval.
+  rpc RefreshImage(RefreshImageRequest) returns (RefreshImageResponse);
+
+  // --- Internal ---
+  // Resolve a reference to an upstream repository and credential. Used by the
+  // Agents service to validate a reference on write, and by the Image Proxy to
+  // serve a pull. Internal only - restricted by Istio, not by an identity
+  // check.
+  rpc ResolveVersion(ResolveVersionRequest) returns (ResolveVersionResponse);
+  // Create an image if no image of that name exists in the organization, and
+  // return the existing one otherwise. Never updates, so re-running an upgrade
+  // cannot overwrite a change someone made by hand. Internal only.
+  rpc RegisterPlatformImage(RegisterPlatformImageRequest) returns (RegisterPlatformImageResponse);
+}
+
+// ===========================================================================
+// Common
+// ===========================================================================
+
+// Metadata shared by every resource.
+message EntityMeta {
+  string id = 1; // UUID
+  google.protobuf.Timestamp created_at = 2;
+  google.protobuf.Timestamp updated_at = 3;
+}
+
+// ===========================================================================
+// Enums
+// ===========================================================================
+
+// Which slot in a workload the image is built for.
+enum ImageType {
+  IMAGE_TYPE_UNSPECIFIED = 0;
+  // The workload's main container - a devcontainer.
+  IMAGE_TYPE_WORKSPACE = 1;
+  // An init container supplying an agent CLI binary and its config.json.
+  IMAGE_TYPE_AGENT_RUNTIME = 2;
+  // A sidecar container running an MCP server.
+  IMAGE_TYPE_MCP = 3;
+}
+
+// Who may read - and therefore use - the image.
+enum ImageVisibility {
+  IMAGE_VISIBILITY_UNSPECIFIED = 0;
+  // Readable by members of the owning organization.
+  IMAGE_VISIBILITY_INTERNAL = 1;
+  // Readable by any authenticated identity, on any organization.
+  IMAGE_VISIBILITY_PUBLIC = 2;
+}
+
+enum ImageVersionState {
+  IMAGE_VERSION_STATE_UNSPECIFIED = 0;
+  // The tag is listed upstream.
+  IMAGE_VERSION_STATE_PRESENT = 1;
+  // The tag is no longer listed upstream. Marked rather than deleted, so
+  // environments naming it can be reported as unschedulable.
+  IMAGE_VERSION_STATE_GONE = 2;
+}
+
+// ===========================================================================
+// Image
+// ===========================================================================
+
+message Image {
+  EntityMeta meta = 1;
+  string organization_id = 2; // UUID - owning organization
+  string name = 3; // Unique within the organization
+  string description = 4;
+  ImageType type = 5; // Immutable
+  string repository = 6; // Upstream repository, e.g. "ghcr.io/agynio/devcontainer-go". Immutable
+  string username = 7; // Registry username. Empty for anonymously readable repositories
+  string secret_id = 8; // UUID - Secret holding the registry password. Empty when there is none
+  ImageVisibility visibility = 9;
+  string tag_filter = 10; // Optional pattern limiting which tags appear in pickers
+  // Set when discovery cannot reach the repository. Stored versions continue
+  // to be served while this is set.
+  optional google.protobuf.Timestamp stale_since = 11;
+  // When discovery last completed successfully.
+  optional google.protobuf.Timestamp last_discovery_at = 12;
+}
+
+message CreateImageRequest {
+  string organization_id = 1;
+  string name = 2;
+  string description = 3;
+  ImageType type = 4;
+  string repository = 5;
+  string username = 6;
+  // Registry password. Write-only: stored as a Secret owned by the same
+  // organization and never returned.
+  string password = 7;
+  ImageVisibility visibility = 8;
+  string tag_filter = 9;
+}
+
+message CreateImageResponse {
+  Image image = 1;
+}
+
+message GetImageRequest {
+  string id = 1; // UUID
+}
+
+message GetImageResponse {
+  Image image = 1;
+}
+
+// repository and type are absent deliberately: both are statements about what
+// the record is, and changing either silently redefines every environment
+// referencing it.
+message UpdateImageRequest {
+  string id = 1; // UUID
+  optional string name = 2;
+  optional string description = 3;
+  optional string username = 4;
+  optional string password = 5;
+  optional ImageVisibility visibility = 6;
+  optional string tag_filter = 7;
+}
+
+message UpdateImageResponse {
+  Image image = 1;
+}
+
+message DeleteImageRequest {
+  string id = 1; // UUID
+}
+
+message DeleteImageResponse {}
+
+// Lists the images available to an organization: its own, plus every public
+// image on the platform.
+message ListImagesRequest {
+  int32 page_size = 1;
+  string page_token = 2;
+  string organization_id = 3;
+  // Optional filter. IMAGE_TYPE_UNSPECIFIED returns every type.
+  ImageType type = 4;
+}
+
+message ListImagesResponse {
+  repeated Image images = 1;
+  string next_page_token = 2;
+}
+
+// ===========================================================================
+// Version
+// ===========================================================================
+
+// A tag observed in an image's upstream repository. Discovered, never authored.
+message ImageVersion {
+  string id = 1; // UUID
+  string image_id = 2; // UUID
+  string tag = 3; // The tag as it appears upstream
+  optional google.protobuf.Timestamp pushed_at = 4; // Read from the upstream manifest
+  string description = 5; // The image's own org.opencontainers.image.description, when declared
+  ImageVersionState state = 6;
+  google.protobuf.Timestamp discovered_at = 7; // First time the platform observed this tag
+}
+
+message ListVersionsRequest {
+  string image_id = 1; // UUID
+  int32 page_size = 2;
+  string page_token = 3;
+  // Include versions whose tag is no longer listed upstream. Off by default:
+  // pickers show what can be selected, and a gone tag cannot.
+  bool include_gone = 4;
+}
+
+message ListVersionsResponse {
+  repeated ImageVersion versions = 1;
+  string next_page_token = 2;
+}
+
+message RefreshImageRequest {
+  string image_id = 1; // UUID
+}
+
+message RefreshImageResponse {
+  // The image after the pass, carrying updated staleness.
+  Image image = 1;
+  // Every present version after the pass, newest first. A refresh is triggered
+  // by a picker or an image page opening, both of which want the list.
+  repeated ImageVersion versions = 2;
+}
+
+// ===========================================================================
+// Internal
+// ===========================================================================
+
+// Names an image by owning organization and name, which is what the image
+// proxy's reference path encodes once it has resolved the organization slug.
+message ImageRef {
+  string organization_id = 1; // UUID
+  string name = 2;
+}
+
+message ResolveVersionRequest {
+  oneof reference {
+    string image_id = 1; // UUID
+    ImageRef ref = 2;
+  }
+  string tag = 3;
+  // Optional. When set, visibility is enforced against this organization: the
+  // image must be owned by it or be public. The Agents service passes the
+  // organization whose environment holds the reference.
+  string consumer_organization_id = 4;
+  // Optional. When set, the resolved image must be of this type. The Agents
+  // service passes the type the slot requires.
+  ImageType require_type = 5;
+}
+
+message ResolveVersionResponse {
+  Image image = 1;
+  // Upstream repository the pull is served from.
+  string repository = 2;
+  // The tag as it will be requested upstream.
+  string tag = 3;
+  // State of the resolved version. A gone tag resolves so the caller can
+  // report it, rather than failing as though the reference were malformed.
+  ImageVersionState state = 4;
+  // Registry credential for the repository. Empty for anonymously readable
+  // repositories.
+  string username = 5;
+  string password = 6;
+}
+
+message RegisterPlatformImageRequest {
+  string organization_id = 1;
+  string name = 2;
+  string description = 3;
+  ImageType type = 4;
+  string repository = 5;
+  string username = 6;
+  string password = 7;
+  ImageVisibility visibility = 8;
+  string tag_filter = 9;
+}
+
+message RegisterPlatformImageResponse {
+  Image image = 1;
+  // False when an image of that name already existed, in which case image is
+  // the existing record, untouched.
+  bool created = 2;
+}

--- a/proto/agynio/api/organizations/v1/organizations.proto
+++ b/proto/agynio/api/organizations/v1/organizations.proto
@@ -16,6 +16,12 @@ service OrganizationsService {
   // Resolve a slug to an organization. Internal: the Image Proxy resolves the
   // slug in a reference path before asking the catalog for the image.
   rpc GetOrganizationBySlug(GetOrganizationBySlugRequest) returns (GetOrganizationBySlugResponse);
+  // Create the organization platform-shipped resources live in, if no
+  // organization holds that slug, and return the existing one otherwise. It has
+  // no members: cluster admins already hold owner-level access to every
+  // organization, so it is administrable without anyone being added to it.
+  // Internal-only, authenticated as a service identity rather than a user.
+  rpc RegisterPlatformOrganization(RegisterPlatformOrganizationRequest) returns (RegisterPlatformOrganizationResponse);
   rpc UpdateOrganization(UpdateOrganizationRequest) returns (UpdateOrganizationResponse);
   rpc DeleteOrganization(DeleteOrganizationRequest) returns (DeleteOrganizationResponse);
   rpc ListOrganizations(ListOrganizationsRequest) returns (ListOrganizationsResponse);
@@ -76,6 +82,18 @@ message CreateOrganizationRequest {
 
 message CreateOrganizationResponse {
   Organization organization = 1;
+}
+
+message RegisterPlatformOrganizationRequest {
+  string slug = 1;
+  string name = 2;
+}
+
+message RegisterPlatformOrganizationResponse {
+  Organization organization = 1;
+  // False when an organization already held that slug, in which case
+  // organization is the existing record, untouched.
+  bool created = 2;
 }
 
 message GetOrganizationBySlugRequest {

--- a/proto/agynio/api/organizations/v1/organizations.proto
+++ b/proto/agynio/api/organizations/v1/organizations.proto
@@ -13,6 +13,9 @@ option go_package = "github.com/agynio/api/gen/agynio/api/organizations/v1;organ
 service OrganizationsService {
   rpc CreateOrganization(CreateOrganizationRequest) returns (CreateOrganizationResponse);
   rpc GetOrganization(GetOrganizationRequest) returns (GetOrganizationResponse);
+  // Resolve a slug to an organization. Internal: the Image Proxy resolves the
+  // slug in a reference path before asking the catalog for the image.
+  rpc GetOrganizationBySlug(GetOrganizationBySlugRequest) returns (GetOrganizationBySlugResponse);
   rpc UpdateOrganization(UpdateOrganizationRequest) returns (UpdateOrganizationResponse);
   rpc DeleteOrganization(DeleteOrganizationRequest) returns (DeleteOrganizationResponse);
   rpc ListOrganizations(ListOrganizationsRequest) returns (ListOrganizationsResponse);
@@ -59,13 +62,27 @@ message Organization {
   google.protobuf.Timestamp updated_at = 4;
   string sandbox_default_idle_timeout = 5;
   string sandbox_default_ttl = 6;
+  // Cluster-wide unique short name. Appears in identifiers that must resolve
+  // without an organization already in context: an app's address and an image
+  // proxy reference. Max 64 chars, pattern ^[a-z0-9-]+$.
+  string slug = 7;
 }
 
 message CreateOrganizationRequest {
   string name = 1;
+  // Optional. Derived from the name when empty.
+  string slug = 2;
 }
 
 message CreateOrganizationResponse {
+  Organization organization = 1;
+}
+
+message GetOrganizationBySlugRequest {
+  string slug = 1;
+}
+
+message GetOrganizationBySlugResponse {
   Organization organization = 1;
 }
 
@@ -82,6 +99,10 @@ message UpdateOrganizationRequest {
   optional string name = 2;
   optional string sandbox_default_idle_timeout = 3;
   optional string sandbox_default_ttl = 4;
+  // A rename is visible: app addresses change and image references change,
+  // which costs a one-time container-image cache miss per node. Nothing breaks,
+  // because neither consumer stores a resolved reference.
+  optional string slug = 5;
 }
 
 message UpdateOrganizationResponse {

--- a/proto/agynio/api/runners/v1/runners.proto
+++ b/proto/agynio/api/runners/v1/runners.proto
@@ -621,9 +621,7 @@ enum AttachmentKind {
   ATTACHMENT_KIND_UNSPECIFIED = 0;
   ATTACHMENT_KIND_AGENT = 1;
   ATTACHMENT_KIND_MCP = 2;
-  // 3 was ATTACHMENT_KIND_HOOK. Reserved rather than reused: a client built
-  // before hooks were removed still sends it.
-  reserved 3;
+  ATTACHMENT_KIND_HOOK = 3 [deprecated = true];
 }
 
 message Attachment {
@@ -636,9 +634,8 @@ enum VolumeAttachmentFilterKind {
   VOLUME_ATTACHMENT_FILTER_KIND_UNSPECIFIED = 0;
   VOLUME_ATTACHMENT_FILTER_KIND_AGENT = 1;
   VOLUME_ATTACHMENT_FILTER_KIND_MCP = 2;
+  VOLUME_ATTACHMENT_FILTER_KIND_HOOK = 3 [deprecated = true];
   VOLUME_ATTACHMENT_FILTER_KIND_UNATTACHED = 4;
-  // 3 was VOLUME_ATTACHMENT_FILTER_KIND_HOOK.
-  reserved 3;
 }
 
 message CreateVolumeRequest {

--- a/proto/agynio/api/runners/v1/runners.proto
+++ b/proto/agynio/api/runners/v1/runners.proto
@@ -621,7 +621,9 @@ enum AttachmentKind {
   ATTACHMENT_KIND_UNSPECIFIED = 0;
   ATTACHMENT_KIND_AGENT = 1;
   ATTACHMENT_KIND_MCP = 2;
-  ATTACHMENT_KIND_HOOK = 3;
+  // 3 was ATTACHMENT_KIND_HOOK. Reserved rather than reused: a client built
+  // before hooks were removed still sends it.
+  reserved 3;
 }
 
 message Attachment {
@@ -634,8 +636,9 @@ enum VolumeAttachmentFilterKind {
   VOLUME_ATTACHMENT_FILTER_KIND_UNSPECIFIED = 0;
   VOLUME_ATTACHMENT_FILTER_KIND_AGENT = 1;
   VOLUME_ATTACHMENT_FILTER_KIND_MCP = 2;
-  VOLUME_ATTACHMENT_FILTER_KIND_HOOK = 3;
   VOLUME_ATTACHMENT_FILTER_KIND_UNATTACHED = 4;
+  // 3 was VOLUME_ATTACHMENT_FILTER_KIND_HOOK.
+  reserved 3;
 }
 
 message CreateVolumeRequest {

--- a/proto/agynio/api/secrets/v1/secrets.proto
+++ b/proto/agynio/api/secrets/v1/secrets.proto
@@ -33,7 +33,15 @@ service SecretsService {
   // Verify that a secret exists without resolving its value.
   rpc ResolveSecretExists(ResolveSecretExistsRequest) returns (ResolveSecretExistsResponse);
 
+  // --- Image Pull Secrets ---
+  rpc CreateImagePullSecret(CreateImagePullSecretRequest) returns (CreateImagePullSecretResponse) { option deprecated = true; }
+  rpc GetImagePullSecret(GetImagePullSecretRequest) returns (GetImagePullSecretResponse) { option deprecated = true; }
+  rpc UpdateImagePullSecret(UpdateImagePullSecretRequest) returns (UpdateImagePullSecretResponse) { option deprecated = true; }
+  rpc DeleteImagePullSecret(DeleteImagePullSecretRequest) returns (DeleteImagePullSecretResponse) { option deprecated = true; }
+  rpc ListImagePullSecrets(ListImagePullSecretsRequest) returns (ListImagePullSecretsResponse) { option deprecated = true; }
 
+  // --- Image Pull Secret Resolution ---
+  rpc ResolveImagePullSecret(ResolveImagePullSecretRequest) returns (ResolveImagePullSecretResponse) { option deprecated = true; }
 }
 
 // ===========================================================================
@@ -221,11 +229,110 @@ message ResolveSecretExistsResponse {
   string organization_id = 2;
 }
 
+// ===========================================================================
+// Image Pull Secret
+// ===========================================================================
+
 message RemoteSecretRef {
   string value_provider_id = 1;
   string value_reference = 2;
 }
 
+// Image pull secrets are deprecated and no longer served: the secrets service
+// returns Unimplemented. Registry credentials belong to an Image record and
+// reach a registry only through the image proxy. Kept here so generated
+// clients still compile; removed in a follow-up.
+
+message ImagePullSecret {
+  option deprecated = true;
+  EntityMeta meta = 1;
+  string description = 2;
+  string registry = 3;
+  string username = 4;
+  oneof source {
+    string value = 5;
+    RemoteSecretRef remote = 6;
+  }
+}
+
+message CreateImagePullSecretRequest {
+  option deprecated = true;
+  string description = 1;
+  string registry = 2;
+  string username = 3;
+  oneof source {
+    string value = 4;
+    RemoteSecretRef remote = 5;
+  }
+  string organization_id = 6;
+}
+
+message CreateImagePullSecretResponse {
+  option deprecated = true;
+  ImagePullSecret image_pull_secret = 1;
+}
+
+message GetImagePullSecretRequest {
+  option deprecated = true;
+  string id = 1; // UUID
+}
+
+message GetImagePullSecretResponse {
+  option deprecated = true;
+  ImagePullSecret image_pull_secret = 1;
+}
+
+message UpdateImagePullSecretRequest {
+  option deprecated = true;
+  string id = 1; // UUID
+  optional string description = 2;
+  optional string registry = 3;
+  optional string username = 4;
+  oneof source {
+    string value = 5;
+    RemoteSecretRef remote = 6;
+  }
+}
+
+message UpdateImagePullSecretResponse {
+  option deprecated = true;
+  ImagePullSecret image_pull_secret = 1;
+}
+
+message DeleteImagePullSecretRequest {
+  option deprecated = true;
+  string id = 1; // UUID
+}
+
+message DeleteImagePullSecretResponse {
+  option deprecated = true;
+}
+
+message ListImagePullSecretsRequest {
+  option deprecated = true;
+  int32 page_size = 1;
+  string page_token = 2;
+  string organization_id = 3;
+}
+
+message ListImagePullSecretsResponse {
+  option deprecated = true;
+  repeated ImagePullSecret image_pull_secrets = 1;
+  string next_page_token = 2;
+}
+
 // ===========================================================================
 // Image Pull Secret Resolution
 // ===========================================================================
+
+message ResolveImagePullSecretRequest {
+  option deprecated = true;
+  string id = 1; // UUID of the ImagePullSecret to resolve
+}
+
+message ResolveImagePullSecretResponse {
+  option deprecated = true;
+  string registry = 1;
+  string username = 2;
+  string password = 3;
+}

--- a/proto/agynio/api/secrets/v1/secrets.proto
+++ b/proto/agynio/api/secrets/v1/secrets.proto
@@ -34,14 +34,26 @@ service SecretsService {
   rpc ResolveSecretExists(ResolveSecretExistsRequest) returns (ResolveSecretExistsResponse);
 
   // --- Image Pull Secrets ---
-  rpc CreateImagePullSecret(CreateImagePullSecretRequest) returns (CreateImagePullSecretResponse) { option deprecated = true; }
-  rpc GetImagePullSecret(GetImagePullSecretRequest) returns (GetImagePullSecretResponse) { option deprecated = true; }
-  rpc UpdateImagePullSecret(UpdateImagePullSecretRequest) returns (UpdateImagePullSecretResponse) { option deprecated = true; }
-  rpc DeleteImagePullSecret(DeleteImagePullSecretRequest) returns (DeleteImagePullSecretResponse) { option deprecated = true; }
-  rpc ListImagePullSecrets(ListImagePullSecretsRequest) returns (ListImagePullSecretsResponse) { option deprecated = true; }
+  rpc CreateImagePullSecret(CreateImagePullSecretRequest) returns (CreateImagePullSecretResponse) {
+    option deprecated = true;
+  }
+  rpc GetImagePullSecret(GetImagePullSecretRequest) returns (GetImagePullSecretResponse) {
+    option deprecated = true;
+  }
+  rpc UpdateImagePullSecret(UpdateImagePullSecretRequest) returns (UpdateImagePullSecretResponse) {
+    option deprecated = true;
+  }
+  rpc DeleteImagePullSecret(DeleteImagePullSecretRequest) returns (DeleteImagePullSecretResponse) {
+    option deprecated = true;
+  }
+  rpc ListImagePullSecrets(ListImagePullSecretsRequest) returns (ListImagePullSecretsResponse) {
+    option deprecated = true;
+  }
 
   // --- Image Pull Secret Resolution ---
-  rpc ResolveImagePullSecret(ResolveImagePullSecretRequest) returns (ResolveImagePullSecretResponse) { option deprecated = true; }
+  rpc ResolveImagePullSecret(ResolveImagePullSecretRequest) returns (ResolveImagePullSecretResponse) {
+    option deprecated = true;
+  }
 }
 
 // ===========================================================================

--- a/proto/agynio/api/secrets/v1/secrets.proto
+++ b/proto/agynio/api/secrets/v1/secrets.proto
@@ -33,15 +33,7 @@ service SecretsService {
   // Verify that a secret exists without resolving its value.
   rpc ResolveSecretExists(ResolveSecretExistsRequest) returns (ResolveSecretExistsResponse);
 
-  // --- Image Pull Secrets ---
-  rpc CreateImagePullSecret(CreateImagePullSecretRequest) returns (CreateImagePullSecretResponse);
-  rpc GetImagePullSecret(GetImagePullSecretRequest) returns (GetImagePullSecretResponse);
-  rpc UpdateImagePullSecret(UpdateImagePullSecretRequest) returns (UpdateImagePullSecretResponse);
-  rpc DeleteImagePullSecret(DeleteImagePullSecretRequest) returns (DeleteImagePullSecretResponse);
-  rpc ListImagePullSecrets(ListImagePullSecretsRequest) returns (ListImagePullSecretsResponse);
 
-  // --- Image Pull Secret Resolution ---
-  rpc ResolveImagePullSecret(ResolveImagePullSecretRequest) returns (ResolveImagePullSecretResponse);
 }
 
 // ===========================================================================
@@ -229,91 +221,11 @@ message ResolveSecretExistsResponse {
   string organization_id = 2;
 }
 
-// ===========================================================================
-// Image Pull Secret
-// ===========================================================================
-
 message RemoteSecretRef {
   string value_provider_id = 1;
   string value_reference = 2;
 }
 
-message ImagePullSecret {
-  EntityMeta meta = 1;
-  string description = 2;
-  string registry = 3;
-  string username = 4;
-  oneof source {
-    string value = 5;
-    RemoteSecretRef remote = 6;
-  }
-}
-
-message CreateImagePullSecretRequest {
-  string description = 1;
-  string registry = 2;
-  string username = 3;
-  oneof source {
-    string value = 4;
-    RemoteSecretRef remote = 5;
-  }
-  string organization_id = 6;
-}
-
-message CreateImagePullSecretResponse {
-  ImagePullSecret image_pull_secret = 1;
-}
-
-message GetImagePullSecretRequest {
-  string id = 1; // UUID
-}
-
-message GetImagePullSecretResponse {
-  ImagePullSecret image_pull_secret = 1;
-}
-
-message UpdateImagePullSecretRequest {
-  string id = 1; // UUID
-  optional string description = 2;
-  optional string registry = 3;
-  optional string username = 4;
-  oneof source {
-    string value = 5;
-    RemoteSecretRef remote = 6;
-  }
-}
-
-message UpdateImagePullSecretResponse {
-  ImagePullSecret image_pull_secret = 1;
-}
-
-message DeleteImagePullSecretRequest {
-  string id = 1; // UUID
-}
-
-message DeleteImagePullSecretResponse {}
-
-message ListImagePullSecretsRequest {
-  int32 page_size = 1;
-  string page_token = 2;
-  string organization_id = 3;
-}
-
-message ListImagePullSecretsResponse {
-  repeated ImagePullSecret image_pull_secrets = 1;
-  string next_page_token = 2;
-}
-
 // ===========================================================================
 // Image Pull Secret Resolution
 // ===========================================================================
-
-message ResolveImagePullSecretRequest {
-  string id = 1; // UUID of the ImagePullSecret to resolve
-}
-
-message ResolveImagePullSecretResponse {
-  string registry = 1;
-  string username = 2;
-  string password = 3;
-}


### PR DESCRIPTION
Adds the image catalog and the pull proxy to the API, and removes the two mechanisms they replace.

## New services

- **`images/v1`** — `ImagesService`. Register an image once (repository + credential + optional tag filter); the platform discovers its versions and serves them. `ResolveVersion`/`ResolveImage`/`RegisterPlatformImage` are internal-only and restricted by an AuthorizationPolicy; the other RPCs are user-facing through the Gateway.
- **`image_proxy/v1`** — `MintPullCredential`/`RevokePullCredential`. One short-lived Basic credential per workload, scoped to the images that workload may pull.
- **`gateway/v1/images.proto`** — the seven user-facing RPCs only.

## Changed

- `Environment` gains `workspace_image_id/_tag` and `agent_runtime_image_id/_tag`. An environment with a workspace image and no agent runtime is workspace-only: a sandbox can use it, creating an agent against it is rejected.
- `Mcp` gains `image_id/_tag` (type `mcp` or `workspace` — a purpose-built server and a devcontainer are both legitimate ways to host one).
- `Organization` gains a cluster-wide unique `slug`, plus `GetOrganizationBySlug` and `RegisterPlatformOrganization`. The slug is the first path segment of every proxied pull.
- `Agent.image`/`resources` were already deprecated; they stay.

## Deprecated — nothing removed

`buf breaking` against `main` is clean: the whole surface stays so generated clients keep compiling. It is no longer *served* — the agents and secrets services embed the generated `Unimplemented` server and answer `Unimplemented`; the Gateway still forwards. A follow-up deletes it once consumers have moved.

- **Hooks**: `Hook`, its five RPCs and the `hook_id` targets, plus `ATTACHMENT_KIND_HOOK` and `VOLUME_ATTACHMENT_FILTER_KIND_HOOK` in `runners/v1`. Hooks are the last resource carrying a free-form image reference, which is what the catalog exists to remove.
- **Image pull secrets**: `ImagePullSecret`, its resolution RPCs, and `ImagePullSecretAttachment`. Per-workload credentials from the proxy replace them, which also removes the conflict where two attachments carried different credentials for one registry hostname.
- **Fields**: `Environment.image` and `Mcp.image` join the already-deprecated `Agent.image`/`Agent.resources`.

## Consumers

Every consumer repo is implemented and green against the local VM, each currently building from a vendored `proto/` shim marked for deletion. Merging this lets those shims go: `image-catalog`, `image-pull-proxy`, `agents`, `agents-orchestrator`, `organizations`, `secrets`, `runners`, `k8s-runner`, `console-app`, `terraform-provider-agyn`.

Verified end to end on the bundle VM: an environment naming a catalog image assembles a sandbox at `registry.agyn.dev/<org-slug>/<image>:<tag>`, the orchestrator mints and attaches the pull credential, and the pod reaches Running.

