### PR TITLE
feat(images): carry the owning organization's name

### DIFF
--- a/proto/agynio/api/images/v1/images.proto
+++ b/proto/agynio/api/images/v1/images.proto
@@ -109,6 +109,10 @@ message Image {
   optional google.protobuf.Timestamp stale_since = 11;
   // When discovery last completed successfully.
   optional google.protobuf.Timestamp last_discovery_at = 12;
+  // The owning organization's name, resolved on read. A public image is listed
+  // to organizations that cannot read the owner's record, and a bare id tells
+  // the reader nothing about who is sharing it.
+  string organization_name = 13;
 }
 
 message CreateImageRequest {


### PR DESCRIPTION
`Image` gains `organization_name`, resolved on read by the images service.

A public image is listed to organizations that are not members of the owner, so they cannot read that organization's record — a bare `organization_id` tells the reader nothing about who is shared it with them. The console shows shared images as `<owner>/<image>`.

Additive; `buf breaking` against main is clean.