### PR TITLE
feat(images): identify a shared image's owner by slug

### DIFF
--- a/proto/agynio/api/images/v1/images.proto
+++ b/proto/agynio/api/images/v1/images.proto
@@ -109,9 +109,9 @@ message Image {
   optional google.protobuf.Timestamp stale_since = 11;
   // When discovery last completed successfully.
   optional google.protobuf.Timestamp last_discovery_at = 12;
-  // Superseded by organization_slug: a name is not unique platform-wide, so it
-  // cannot identify an owner on its own.
-  string organization_name = 13 [deprecated = true];
+  // The owning organization's display name. Not an identifier - two
+  // organizations may share one - but the readable half of an attribution.
+  string organization_name = 13;
   // The owning organization's slug, resolved on read. A public image is listed
   // to organizations that cannot read the owner's record, and a bare id tells
   // the reader nothing about who is sharing it. The slug rather than the name:

--- a/proto/agynio/api/images/v1/images.proto
+++ b/proto/agynio/api/images/v1/images.proto
@@ -109,10 +109,15 @@ message Image {
   optional google.protobuf.Timestamp stale_since = 11;
   // When discovery last completed successfully.
   optional google.protobuf.Timestamp last_discovery_at = 12;
-  // The owning organization's name, resolved on read. A public image is listed
+  // Superseded by organization_slug: a name is not unique platform-wide, so it
+  // cannot identify an owner on its own.
+  string organization_name = 13 [deprecated = true];
+  // The owning organization's slug, resolved on read. A public image is listed
   // to organizations that cannot read the owner's record, and a bare id tells
-  // the reader nothing about who is sharing it.
-  string organization_name = 13;
+  // the reader nothing about who is sharing it. The slug rather than the name:
+  // it is unique platform-wide and is what the image proxy already puts in
+  // every rewritten reference, so one identifier names the owner everywhere.
+  string organization_slug = 14;
 }
 
 message CreateImageRequest {


### PR DESCRIPTION
`Image.organization_slug` replaces `organization_name` (deprecated, not removed).

A name is not unique platform-wide, so it cannot identify an owner on its own. The slug is already what the image proxy puts in every rewritten reference (`registry.<domain>/<org-slug>/<image>`), so one identifier names the owner everywhere.

`buf breaking` against main is clean.