### PR TITLE
Take a session kind on terminal sessions

### DIFF
--- a/proto/agynio/api/gateway/v1/terminal.proto
+++ b/proto/agynio/api/gateway/v1/terminal.proto
@@ -14,15 +14,15 @@ message CreateTerminalSessionRequest {
   string workload_id = 1;
   string container_name = 2;
 
-  // Set only for EXEC. The Gateway derives the command for every other kind,
-  // so a client cannot escalate beyond what its kind was authorized for.
+  // The command to run. Meaningful only when kind is EXEC; every other kind
+  // has a platform-defined command and ignores this field.
   optional agynio.api.terminal_proxy.v1.TerminalCommand command = 3;
 
   // Required. UNSPECIFIED is rejected with InvalidArgument.
-  agynio.api.terminal_proxy.v1.TerminalSessionKind kind = 4;
+  agynio.api.terminal_proxy.v1.SessionKind kind = 4;
 
-  // Set only for SYNC: the directory to serve, validated as absolute and
-  // normalized before being bound into the ticket.
+  // The directory to serve. Meaningful only when kind is SYNC. Must be
+  // absolute.
   string sync_root = 5;
 }
 

--- a/proto/agynio/api/gateway/v1/terminal.proto
+++ b/proto/agynio/api/gateway/v1/terminal.proto
@@ -13,7 +13,17 @@ service TerminalGateway {
 message CreateTerminalSessionRequest {
   string workload_id = 1;
   string container_name = 2;
+
+  // Set only for EXEC. The Gateway derives the command for every other kind,
+  // so a client cannot escalate beyond what its kind was authorized for.
   optional agynio.api.terminal_proxy.v1.TerminalCommand command = 3;
+
+  // Required. UNSPECIFIED is rejected with InvalidArgument.
+  agynio.api.terminal_proxy.v1.TerminalSessionKind kind = 4;
+
+  // Set only for SYNC: the directory to serve, validated as absolute and
+  // normalized before being bound into the ticket.
+  string sync_root = 5;
 }
 
 message CreateTerminalSessionResponse {

--- a/proto/agynio/api/terminal_proxy/v1/terminal_proxy.proto
+++ b/proto/agynio/api/terminal_proxy/v1/terminal_proxy.proto
@@ -9,6 +9,28 @@ service TerminalProxyService {
   rpc IssueTicket(IssueTicketRequest) returns (IssueTicketResponse);
 }
 
+// TerminalSessionKind selects what the platform runs. The Gateway holds the
+// command for each kind, so a client never supplies one and the ticket always
+// describes something the platform defined.
+enum TerminalSessionKind {
+  // Rejected with InvalidArgument. It does not default to SHELL: silently
+  // defaulting the field that selects a command is how an unintended command
+  // ends up in a ticket.
+  TERMINAL_SESSION_KIND_UNSPECIFIED = 0;
+
+  // A login shell, TTY. The platform binaries are put on PATH after the login
+  // profile runs, since /etc/profile assigns PATH outright on common bases.
+  TERMINAL_SESSION_KIND_SHELL = 1;
+
+  // A caller-supplied command, TTY. Authorized by the same check as SHELL —
+  // binding the command at issuance buys immutability, not permission.
+  TERMINAL_SESSION_KIND_EXEC = 2;
+
+  // The workspace sync endpoint. Non-TTY: no PTY, no resize, and stdout kept
+  // separate from stderr so protocol frames are not corrupted by diagnostics.
+  TERMINAL_SESSION_KIND_SYNC = 3;
+}
+
 message IssueTicketRequest {
   // Authenticated identity supplied by Gateway from request context. This
   // field is internal service-to-service data and must never come from client
@@ -16,7 +38,17 @@ message IssueTicketRequest {
   string identity_id = 1;
   string workload_id = 2;
   string container_name = 3;
+
+  // Set only for EXEC. The Gateway derives the command for every other kind.
   TerminalCommand command = 4;
+
+  TerminalSessionKind kind = 5;
+
+  // Set only for SYNC: the directory to serve. The Gateway validates it
+  // lexically — absolute, normalized, no traversal — and the endpoint resolves
+  // it against the real filesystem and confines it to the workspace mount,
+  // which is the only place either can be checked.
+  string sync_root = 6;
 }
 
 message IssueTicketResponse {

--- a/proto/agynio/api/terminal_proxy/v1/terminal_proxy.proto
+++ b/proto/agynio/api/terminal_proxy/v1/terminal_proxy.proto
@@ -9,26 +9,25 @@ service TerminalProxyService {
   rpc IssueTicket(IssueTicketRequest) returns (IssueTicketResponse);
 }
 
-// TerminalSessionKind selects what the platform runs. The Gateway holds the
-// command for each kind, so a client never supplies one and the ticket always
-// describes something the platform defined.
-enum TerminalSessionKind {
+// SessionKind selects what runs in the container. The command for each kind is
+// platform-defined and bound into the ticket at issuance, so a client never
+// supplies one and cannot change it at attach time.
+enum SessionKind {
   // Rejected with InvalidArgument. It does not default to SHELL: silently
   // defaulting the field that selects a command is how an unintended command
   // ends up in a ticket.
-  TERMINAL_SESSION_KIND_UNSPECIFIED = 0;
+  SESSION_KIND_UNSPECIFIED = 0;
 
-  // A login shell, TTY. The platform binaries are put on PATH after the login
-  // profile runs, since /etc/profile assigns PATH outright on common bases.
-  TERMINAL_SESSION_KIND_SHELL = 1;
+  // A login shell on a PTY, with the platform binaries on PATH.
+  SESSION_KIND_SHELL = 1;
 
-  // A caller-supplied command, TTY. Authorized by the same check as SHELL —
+  // A caller-supplied command on a PTY. Carries no more privilege than SHELL —
   // binding the command at issuance buys immutability, not permission.
-  TERMINAL_SESSION_KIND_EXEC = 2;
+  SESSION_KIND_EXEC = 2;
 
   // The workspace sync endpoint. Non-TTY: no PTY, no resize, and stdout kept
-  // separate from stderr so protocol frames are not corrupted by diagnostics.
-  TERMINAL_SESSION_KIND_SYNC = 3;
+  // separate from stderr so diagnostics cannot corrupt protocol frames.
+  SESSION_KIND_SYNC = 3;
 }
 
 message IssueTicketRequest {
@@ -39,15 +38,15 @@ message IssueTicketRequest {
   string workload_id = 2;
   string container_name = 3;
 
-  // Set only for EXEC. The Gateway derives the command for every other kind.
+  // The command to run. Meaningful only when kind is EXEC; every other kind
+  // has a platform-defined command and ignores this field.
   TerminalCommand command = 4;
 
-  TerminalSessionKind kind = 5;
+  SessionKind kind = 5;
 
-  // Set only for SYNC: the directory to serve. The Gateway validates it
-  // lexically — absolute, normalized, no traversal — and the endpoint resolves
-  // it against the real filesystem and confines it to the workspace mount,
-  // which is the only place either can be checked.
+  // The directory to serve. Meaningful only when kind is SYNC. Must be
+  // absolute; it is normalized before being bound into the ticket, and
+  // resolved against the real filesystem inside the container.
   string sync_root = 6;
 }
 


### PR DESCRIPTION
`CreateTerminalSession` took a free-form optional command override. It now takes a **session kind**, and the Gateway holds the command for each one, so the ticket always describes something the platform defined.

| Kind | TTY | Command |
|---|---|---|
| `SHELL` | yes | A login shell, platform binaries put on `PATH` after the profile runs |
| `EXEC` | yes | Caller-supplied, bound at issuance |
| `SYNC` | no | The workspace sync endpoint |

- `UNSPECIFIED` is rejected with `InvalidArgument` rather than defaulting to `SHELL` — silently defaulting the field that selects a command is how an unintended command ends up in a ticket.
- `command` stays, set only for `EXEC`. Authorization does not vary by kind; binding at issuance buys immutability, not permission.
- `sync_root` is validated lexically at the Gateway and resolved against the real filesystem by the endpoint — the only side that can follow symlinks or see where the workspace is mounted.

Additive: existing fields keep their numbers, `buf lint` and `buf breaking` against `main` are both clean.

Spec: [terminal-proxy.md#session-kinds](https://github.com/agynio/architecture/blob/main/architecture/terminal-proxy.md#session-kinds), change [2026-08-04-sandbox-workspace-sync](https://github.com/agynio/architecture/blob/main/changes/2026-08-04-sandbox-workspace-sync.md).

Consumers (`gateway`, `terminal-proxy`, `agyn-cli`, `console-app`) regenerate from the BSR after this merges; their PRs follow.