### PR TITLE
Let a sandbox creator name an idle timeout

### DIFF
--- a/proto/agynio/api/agents/v1/agents.proto
+++ b/proto/agynio/api/agents/v1/agents.proto
@@ -667,6 +667,7 @@ message CreateSandboxRequest {
   string organization_id = 1;
   optional string name = 2;
   string environment_id = 3;
+  optional string idle_timeout = 4;
 }
 
 message CreateSandboxResponse {

--- a/proto/agynio/api/organizations/v1/organizations.proto
+++ b/proto/agynio/api/organizations/v1/organizations.proto
@@ -72,6 +72,7 @@ message Organization {
   // without an organization already in context: an app's address and an image
   // proxy reference. Max 64 chars, pattern ^[a-z0-9-]+$.
   string slug = 7;
+  string sandbox_max_idle_timeout = 8;
 }
 
 message CreateOrganizationRequest {
@@ -121,6 +122,7 @@ message UpdateOrganizationRequest {
   // which costs a one-time container-image cache miss per node. Nothing breaks,
   // because neither consumer stores a resolved reference.
   optional string slug = 5;
+  optional string sandbox_max_idle_timeout = 6;
 }
 
 message UpdateOrganizationResponse {


### PR DESCRIPTION
Adds `CreateSandboxRequest.idle_timeout`, and `sandbox_max_idle_timeout` on
`Organization` and `UpdateOrganizationRequest`.

Additive; `buf breaking` against `main` is clean.

Behaviour, validation and defaults are specified in
`architecture/changes/2026-08-06-sandbox-idle-timeout-control.md` and
implemented in `organizations`, `agents` and `agyn-cli`.

Lands first: services build against `buf.build/agynio/api`, published on merge
to `main`, so the implementations cannot build against the registry until this
merges.