### PR TITLE
Add native LLM mode and subscription contracts

### DIFF
--- a/proto/agynio/api/agents/v1/agents.proto
+++ b/proto/agynio/api/agents/v1/agents.proto
@@ -203,6 +203,15 @@ enum EnvironmentAvailability {
   ENVIRONMENT_AVAILABILITY_PRIVATE = 2;
 }
 
+// How workloads in an environment reach an LLM. PLATFORM points the agent CLI
+// at the LLM Proxy with platform Model IDs; NATIVE leaves the CLI in its stock
+// configuration and intercepts its vendor traffic.
+enum LLMMode {
+  LLM_MODE_UNSPECIFIED = 0;
+  LLM_MODE_PLATFORM = 1;
+  LLM_MODE_NATIVE = 2;
+}
+
 enum EnvironmentRole {
   ENVIRONMENT_ROLE_UNSPECIFIED = 0;
   ENVIRONMENT_ROLE_OWNER = 1;
@@ -258,6 +267,9 @@ message Agent {
   // than the instance. Defaults to DISCARD.
   AgentFinalMessage final_message = 17;
   optional string instance_idle_ttl = 18; // Go duration string (e.g., "30m", "6h").
+  // Vendor model name for native mode, opaque to the platform. Mutually
+  // exclusive with model, which mode the environment is in decides.
+  string model_name = 19;
 }
 
 message CreateAgentRequest {
@@ -280,6 +292,8 @@ message CreateAgentRequest {
   AgentDefaultThread default_thread = 15;
   AgentFinalMessage final_message = 16;
   optional string instance_idle_ttl = 17; // Go duration string (e.g., "30m", "6h").
+  // Required-and-exclusive against model, decided by the environment's llm_mode.
+  string model_name = 18;
 }
 
 message CreateAgentResponse {
@@ -325,6 +339,7 @@ message UpdateAgentRequest {
   optional AgentDefaultThread default_thread = 15;
   optional AgentFinalMessage final_message = 16;
   optional string instance_idle_ttl = 17; // Go duration string (e.g., "30m", "6h").
+  optional string model_name = 18;
 }
 
 message UpdateAgentResponse {
@@ -599,6 +614,11 @@ message Environment {
   string agent_runtime_image_id = 11; // UUID
   string agent_runtime_image_tag = 12;
   EnvironmentAvailability availability = 13;
+  // How workloads here reach an LLM. Defaults to PLATFORM.
+  LLMMode llm_mode = 14;
+  // Vendor model names a native-mode workload may request, enforced by the LLM
+  // Proxy. Empty means no restriction. Ignored in platform mode.
+  repeated string llm_allowed_models = 15;
 }
 
 message CreateEnvironmentRequest {
@@ -613,6 +633,9 @@ message CreateEnvironmentRequest {
   string agent_runtime_image_id = 9; // UUID
   string agent_runtime_image_tag = 10;
   EnvironmentAvailability availability = 11;
+  // Unspecified defaults to PLATFORM.
+  LLMMode llm_mode = 12;
+  repeated string llm_allowed_models = 13;
 }
 
 message CreateEnvironmentResponse {
@@ -640,6 +663,11 @@ message UpdateEnvironmentRequest {
   optional string agent_runtime_image_id = 9; // UUID
   optional string agent_runtime_image_tag = 10;
   optional EnvironmentAvailability availability = 11;
+  // Rejected while any agent references the environment: every such agent's
+  // model / model_name becomes invalid in the other mode.
+  optional LLMMode llm_mode = 12;
+  // Replaces the existing list; an empty list clears the allowlist.
+  repeated string llm_allowed_models = 13;
 }
 
 message UpdateEnvironmentResponse {

--- a/proto/agynio/api/gateway/v1/llm.proto
+++ b/proto/agynio/api/gateway/v1/llm.proto
@@ -21,6 +21,23 @@ service LLMGateway {
   rpc DeleteModel(agynio.api.llm.v1.DeleteModelRequest) returns (agynio.api.llm.v1.DeleteModelResponse);
   rpc ListModels(agynio.api.llm.v1.ListModelsRequest) returns (agynio.api.llm.v1.ListModelsResponse);
 
+  // --- Subscriptions ---
+  rpc CreateSubscription(agynio.api.llm.v1.CreateSubscriptionRequest) returns (agynio.api.llm.v1.CreateSubscriptionResponse);
+  rpc GetSubscription(agynio.api.llm.v1.GetSubscriptionRequest) returns (agynio.api.llm.v1.GetSubscriptionResponse);
+  rpc UpdateSubscription(agynio.api.llm.v1.UpdateSubscriptionRequest) returns (agynio.api.llm.v1.UpdateSubscriptionResponse);
+  rpc DeleteSubscription(agynio.api.llm.v1.DeleteSubscriptionRequest) returns (agynio.api.llm.v1.DeleteSubscriptionResponse);
+  rpc ListSubscriptions(agynio.api.llm.v1.ListSubscriptionsRequest) returns (agynio.api.llm.v1.ListSubscriptionsResponse);
+
+  // --- Subscription attachments ---
+  rpc CreateSubscriptionAttachment(agynio.api.llm.v1.CreateSubscriptionAttachmentRequest) returns (agynio.api.llm.v1.CreateSubscriptionAttachmentResponse);
+  rpc DeleteSubscriptionAttachment(agynio.api.llm.v1.DeleteSubscriptionAttachmentRequest) returns (agynio.api.llm.v1.DeleteSubscriptionAttachmentResponse);
+  rpc ListSubscriptionAttachments(agynio.api.llm.v1.ListSubscriptionAttachmentsRequest) returns (agynio.api.llm.v1.ListSubscriptionAttachmentsResponse);
+
   // --- Test ---
   rpc TestModel(agynio.api.llm.v1.TestModelRequest) returns (agynio.api.llm.v1.TestModelResponse);
 }
+
+// ResolveModel, ResolveSubscription, and CountSubscriptionsReferencingSecret are
+// deliberately absent: they are internal calls over Istio, and a subscription
+// credential is not something an external caller should reach through the
+// Gateway.

--- a/proto/agynio/api/llm/v1/llm.proto
+++ b/proto/agynio/api/llm/v1/llm.proto
@@ -6,7 +6,8 @@ import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/agynio/api/gen/agynio/api/llm/v1;llmv1";
 
-// LLMService manages provider and model resources and resolves models.
+// LLMService manages provider, model, and subscription resources and resolves
+// them for the LLM Proxy.
 service LLMService {
   // --- Providers ---
   rpc CreateLLMProvider(CreateLLMProviderRequest) returns (CreateLLMProviderResponse);
@@ -22,11 +23,28 @@ service LLMService {
   rpc DeleteModel(DeleteModelRequest) returns (DeleteModelResponse);
   rpc ListModels(ListModelsRequest) returns (ListModelsResponse);
 
+  // --- Subscriptions ---
+  rpc CreateSubscription(CreateSubscriptionRequest) returns (CreateSubscriptionResponse);
+  rpc GetSubscription(GetSubscriptionRequest) returns (GetSubscriptionResponse);
+  rpc UpdateSubscription(UpdateSubscriptionRequest) returns (UpdateSubscriptionResponse);
+  rpc DeleteSubscription(DeleteSubscriptionRequest) returns (DeleteSubscriptionResponse);
+  rpc ListSubscriptions(ListSubscriptionsRequest) returns (ListSubscriptionsResponse);
+
+  // --- Subscription attachments ---
+  rpc CreateSubscriptionAttachment(CreateSubscriptionAttachmentRequest) returns (CreateSubscriptionAttachmentResponse);
+  rpc DeleteSubscriptionAttachment(DeleteSubscriptionAttachmentRequest) returns (DeleteSubscriptionAttachmentResponse);
+  rpc ListSubscriptionAttachments(ListSubscriptionAttachmentsRequest) returns (ListSubscriptionAttachmentsResponse);
+
   // --- Test ---
   rpc TestModel(TestModelRequest) returns (TestModelResponse);
 
   // --- Resolution ---
   rpc ResolveModel(ResolveModelRequest) returns (ResolveModelResponse);
+  rpc ResolveSubscription(ResolveSubscriptionRequest) returns (ResolveSubscriptionResponse);
+
+  // --- Internal ---
+  // Secrets -> refuse deleting a secret a subscription references.
+  rpc CountSubscriptionsReferencingSecret(CountSubscriptionsReferencingSecretRequest) returns (CountSubscriptionsReferencingSecretResponse);
 }
 
 // ===========================================================================
@@ -53,6 +71,15 @@ enum Protocol {
   PROTOCOL_UNSPECIFIED = 0;
   PROTOCOL_RESPONSES = 1;
   PROTOCOL_ANTHROPIC_MESSAGES = 2;
+}
+
+// Vendor whose own consumer plan a Subscription holds a credential for. Closed:
+// each value fixes an intercepted host, an upstream, a protocol, a header set,
+// and the container placeholder variable name.
+enum Vendor {
+  VENDOR_UNSPECIFIED = 0;
+  VENDOR_CLAUDE = 1;
+  VENDOR_CODEX = 2;
 }
 
 // ===========================================================================
@@ -176,6 +203,135 @@ message ListModelsResponse {
 }
 
 // ===========================================================================
+// Subscription
+// ===========================================================================
+
+message Subscription {
+  EntityMeta meta = 1;
+  string name = 2;
+  Vendor vendor = 3;
+  // The token is held by reference. The value is resolved at binding time and
+  // never stored or returned here.
+  string secret_id = 4; // UUID
+  // Empty unless the vendor's API requires an account identifier. Not a secret.
+  string account_id = 5;
+  string organization_id = 6; // UUID
+}
+
+message CreateSubscriptionRequest {
+  string organization_id = 1;
+  string name = 2;
+  Vendor vendor = 3;
+  string secret_id = 4; // UUID
+  string account_id = 5;
+}
+
+message CreateSubscriptionResponse {
+  Subscription subscription = 1;
+}
+
+message GetSubscriptionRequest {
+  string id = 1; // UUID
+}
+
+message GetSubscriptionResponse {
+  Subscription subscription = 1;
+}
+
+// vendor is absent deliberately: changing it would silently redirect every
+// workload the subscription is attached to.
+message UpdateSubscriptionRequest {
+  string id = 1; // UUID
+  optional string name = 2;
+  optional string secret_id = 3; // UUID
+  optional string account_id = 4;
+}
+
+message UpdateSubscriptionResponse {
+  Subscription subscription = 1;
+}
+
+message DeleteSubscriptionRequest {
+  string id = 1; // UUID
+}
+
+message DeleteSubscriptionResponse {}
+
+message ListSubscriptionsRequest {
+  int32 page_size = 1;
+  string page_token = 2;
+  string organization_id = 3;
+}
+
+message ListSubscriptionsResponse {
+  repeated Subscription subscriptions = 1;
+  string next_page_token = 2;
+}
+
+// ===========================================================================
+// Subscription attachment
+// ===========================================================================
+
+// Binds a Subscription to an agent or an environment. Unique on
+// (vendor, target): an intercepted request carries nothing that identifies a
+// credential, so the resolution key must never have two candidates.
+message SubscriptionAttachment {
+  EntityMeta meta = 1;
+  string subscription_id = 2; // UUID
+  // Denormalized from the subscription, which cannot change vendor. Carried
+  // here so the orchestrator gets role attributes without a second call.
+  Vendor vendor = 3;
+  // Name of the container environment variable holding this vendor's
+  // placeholder credential. Empty for a vendor that has none.
+  string placeholder_env = 4;
+  oneof target {
+    string agent_id = 5; // UUID
+    string environment_id = 6; // UUID
+  }
+}
+
+message CreateSubscriptionAttachmentRequest {
+  string subscription_id = 1; // UUID
+  oneof target {
+    string agent_id = 2; // UUID
+    string environment_id = 3; // UUID
+  }
+}
+
+message CreateSubscriptionAttachmentResponse {
+  SubscriptionAttachment subscription_attachment = 1;
+}
+
+message DeleteSubscriptionAttachmentRequest {
+  string id = 1; // UUID
+}
+
+message DeleteSubscriptionAttachmentResponse {}
+
+message ListSubscriptionAttachmentsRequest {
+  string organization_id = 1;
+  optional string subscription_id = 2; // UUID
+  optional string agent_id = 3; // UUID
+  optional string environment_id = 4; // UUID
+  int32 page_size = 5;
+  string page_token = 6;
+}
+
+message ListSubscriptionAttachmentsResponse {
+  repeated SubscriptionAttachment subscription_attachments = 1;
+  string next_page_token = 2;
+}
+
+message CountSubscriptionsReferencingSecretRequest {
+  string secret_id = 1; // UUID
+}
+
+message CountSubscriptionsReferencingSecretResponse {
+  int32 count = 1;
+  repeated string subscription_ids = 2;
+}
+
+// ===========================================================================
 // Test
 // ===========================================================================
 
@@ -202,4 +358,30 @@ message ResolveModelResponse {
   string organization_id = 4; // UUID
   Protocol protocol = 5;
   AuthMethod auth_method = 6;
+}
+
+// Both identifiers come from the caller's OpenZiti identity; neither is
+// self-asserted by the workload. vendor is the intercept service the connection
+// arrived on.
+message ResolveSubscriptionRequest {
+  // Empty for a sandbox, which runs no agent class.
+  string agent_id = 1; // UUID
+  string environment_id = 2; // UUID
+  Vendor vendor = 3;
+}
+
+// Everything the proxy needs to serve a native-mode connection, so it performs
+// no configuration lookups of its own. placeholder_env is deliberately absent:
+// the proxy strips Authorization and x-api-key whatever they were called.
+message ResolveSubscriptionResponse {
+  // Metering records this as resource_id; the proxy has no other source.
+  string subscription_id = 1; // UUID
+  string token = 2;
+  string account_id = 3;
+  string upstream_endpoint = 4;
+  Protocol protocol = 5;
+  // The environment's llm_allowed_models, read by the LLM service from Agents.
+  // Empty means no restriction.
+  repeated string allowed_models = 6;
+  string organization_id = 7; // UUID
 }

--- a/proto/agynio/api/ziti_management/v1/ziti_management.proto
+++ b/proto/agynio/api/ziti_management/v1/ziti_management.proto
@@ -136,12 +136,18 @@ message ManagedIdentity {
 }
 
 message CreateAgentIdentityRequest {
+  // The agent instance this workload serves; it is what the identity resolves to.
   string agent_id = 1;
   string workload_id = 2;
   // Extra role attributes such as group-<id>. Base agent attributes are added by Ziti Management.
   repeated string additional_role_attributes = 3;
   // Tags attached to the OpenZiti identity.
   map<string, string> tags = 4;
+  // The class the instance was spawned from, and the environment it runs.
+  // Recorded on the identity so a data-plane service can answer "what is this
+  // workload configured to do" from the connection alone.
+  string agent_class_id = 5;
+  string environment_id = 6;
 }
 
 message CreateAgentIdentityResponse {
@@ -321,6 +327,10 @@ message ResolveIdentityResponse {
   string identity_id = 1;
   agynio.api.identity.v1.IdentityType identity_type = 2;
   optional string workload_id = 3;
+  // Workload identities only. agent_id is additionally absent for a sandbox,
+  // which runs an environment with no agent behind it.
+  optional string agent_id = 4;
+  optional string environment_id = 5;
 }
 
 message RequestServiceIdentityRequest {


### PR DESCRIPTION
Contracts for native LLM mode: an environment-level `llm_mode` where an agent CLI runs in its stock configuration addressing its vendor directly, its traffic intercepted at the OpenZiti layer onto the LLM Proxy, which strips the container's placeholder credential and injects a real subscription token.

Spec: `architecture/changes/2026-08-07-llm-native-mode-and-subscriptions.md`.

This is contracts only. Nothing here changes behavior on its own, and every field is additive — `buf breaking` against `main` is clean.

## What is added

**`llm/v1`** — `Vendor` (closed set: `claude`, `codex`), `Subscription`, `SubscriptionAttachment`, their CRUD, plus two internal RPCs:

- `ResolveSubscription(agent_id, environment_id, vendor)` returns the token, upstream, protocol, **and** the environment's `allowed_models` and the `subscription_id`. Returning all of it is deliberate: the proxy must serve a connection without any configuration lookup of its own. `subscription_id` has no other source and is metering's `resource_id`; `allowed_models` is what keeps the proxy free of an Agents dependency on the request path.
- `CountSubscriptionsReferencingSecret` for the Secrets service's delete guard.

A subscription holds its token **by reference** to a Secret, unlike `LLMProvider.token`, which is inline.

`placeholder_env` is on the **attachment**, not on `ResolveSubscription`. The proxy strips `Authorization` and `x-api-key` unconditionally and never needs the name; the orchestrator is its only consumer.

**`agents/v1`** — `LLMMode` and `llm_allowed_models` on `Environment`, `model_name` on `Agent`, with Create/Update variants. `model` and `model_name` are required-and-exclusive against the environment's mode, validated at `CreateAgent`/`UpdateAgent` so a mismatch fails when someone configures it rather than when the agent runs.

**`ziti_management/v1`** — `ResolveIdentityResponse` gains `agent_id` and `environment_id`, recorded at identity creation. Without them the proxy either calls Agents on the request path or trusts a value the workload asserts about itself. Neither is acceptable.

**`gateway/v1/llm.proto`** — subscription CRUD passthrough. The resolvers are deliberately absent: they authenticate by workload identity and are not exposed on the public ingress.

## Design notes

**`SubscriptionAttachment` is unique on `(vendor, target)`.** This is load-bearing, not a simplification — an intercepted request carries nothing identifying a credential, so `(caller, vendor)` has to resolve to exactly one. Agent scope shadows environment scope for the same vendor. Postgres cannot express uniqueness across a join, so the implementation denormalizes `vendor` onto the attachment and uses two partial unique indexes; the field is on the message for the same reason the orchestrator wants it — role attributes without a second call.

**`codex` is declared, not shipped.** `CreateSubscription` returns `UNIMPLEMENTED` for it. The enum value and vendor binding fix the shape, but no coherent placeholder exists yet: the variable a Codex CLI reads (`OPENAI_API_KEY`) selects its *API-key* mode, and a Codex CLI in API-key mode addresses `api.openai.com` — not the `chatgpt.com` the intercept service captures. Its subscription credential lives in `~/.codex/auth.json`, and the placeholder mechanism delivers environment variables only.

## Sequencing

This lands first — seven services regenerate their stubs from the published module and cannot build against the new contract until it is available. Implementation branches exist for `ziti-management`, `agents`, `agents-orchestrator`, `llm`, `secrets`, `gateway`, `llm-proxy`, `metering`, `agynd-cli`, `agyn-cli`, `console-app`, `bundle-vm` and `e2e`; all build and test clean locally, and `llm` is deployed from source on the local VM with its migration applied.
