### PR TITLE
Name vendors after their APIs and split placeholder delivery

### DIFF
--- a/proto/agynio/api/llm/v1/llm.proto
+++ b/proto/agynio/api/llm/v1/llm.proto
@@ -76,8 +76,6 @@ enum Protocol {
 // Vendor whose own consumer plan a Subscription holds a credential for. Closed:
 // each value fixes an intercepted host, an upstream, a protocol, a header set,
 // and the container placeholder variable name.
-// Named after the API the credential authenticates. The old names are aliases
-// on the same numbers.
 enum Vendor {
   // buf:lint:ignore ENUM_NO_ALLOW_ALIAS
   option allow_alias = true;
@@ -88,8 +86,6 @@ enum Vendor {
   VENDOR_CODEX = 2 [deprecated = true];
 }
 
-// How a vendor's placeholder credential reaches the container. ENV is the
-// orchestrator's to set; FILE is agynd's to write.
 enum PlaceholderKind {
   PLACEHOLDER_KIND_UNSPECIFIED = 0;
   PLACEHOLDER_KIND_ENV = 1;
@@ -296,9 +292,8 @@ message SubscriptionAttachment {
   // here so the orchestrator gets role attributes without a second call.
   Vendor vendor = 3;
   PlaceholderKind placeholder_kind = 7;
-  // ENV kind only.
   string placeholder_env = 4;
-  // FILE kind only. Path is relative to HOME.
+  // Relative to HOME.
   string placeholder_path = 8;
   string placeholder_contents = 9;
   oneof target {

--- a/proto/agynio/api/llm/v1/llm.proto
+++ b/proto/agynio/api/llm/v1/llm.proto
@@ -76,10 +76,24 @@ enum Protocol {
 // Vendor whose own consumer plan a Subscription holds a credential for. Closed:
 // each value fixes an intercepted host, an upstream, a protocol, a header set,
 // and the container placeholder variable name.
+// Named after the API the credential authenticates. The old names are aliases
+// on the same numbers.
 enum Vendor {
+  // buf:lint:ignore ENUM_NO_ALLOW_ALIAS
+  option allow_alias = true;
   VENDOR_UNSPECIFIED = 0;
-  VENDOR_CLAUDE = 1;
-  VENDOR_CODEX = 2;
+  VENDOR_ANTHROPIC = 1;
+  VENDOR_CLAUDE = 1 [deprecated = true];
+  VENDOR_OPENAI = 2;
+  VENDOR_CODEX = 2 [deprecated = true];
+}
+
+// How a vendor's placeholder credential reaches the container. ENV is the
+// orchestrator's to set; FILE is agynd's to write.
+enum PlaceholderKind {
+  PLACEHOLDER_KIND_UNSPECIFIED = 0;
+  PLACEHOLDER_KIND_ENV = 1;
+  PLACEHOLDER_KIND_FILE = 2;
 }
 
 // ===========================================================================
@@ -281,9 +295,12 @@ message SubscriptionAttachment {
   // Denormalized from the subscription, which cannot change vendor. Carried
   // here so the orchestrator gets role attributes without a second call.
   Vendor vendor = 3;
-  // Name of the container environment variable holding this vendor's
-  // placeholder credential. Empty for a vendor that has none.
+  PlaceholderKind placeholder_kind = 7;
+  // ENV kind only.
   string placeholder_env = 4;
+  // FILE kind only. Path is relative to HOME.
+  string placeholder_path = 8;
+  string placeholder_contents = 9;
   oneof target {
     string agent_id = 5; // UUID
     string environment_id = 6; // UUID


### PR DESCRIPTION
Contracts for [OpenAI Subscriptions and Vendor Naming](https://github.com/agynio/architecture/blob/openai-subscriptions-and-vendor-naming/changes/2026-08-08-openai-subscriptions-and-vendor-naming.md).

Additive only — `buf breaking` against `main` is clean, and so is `buf lint`.

## Vendors are named after APIs

`claude`/`codex` become `anthropic`/`openai`. Per the spec this is the *cause* of the OpenAI gap rather than cosmetics: the old row paired `chatgpt.com` — the subscription host a Codex CLI calls at `/backend-api/codex/responses` — with `OPENAI_API_KEY`, the variable that puts a Codex CLI in *API-key* mode addressing `api.openai.com`. Two mutually exclusive configurations in one row, because the row was named after the client rather than the API it opens.

**The old names are retained as aliases on the same numbers.** Nothing on the wire changes, and no consumer has to recompile in lockstep:

```proto
enum Vendor {
  // buf:lint:ignore ENUM_NO_ALLOW_ALIAS
  option allow_alias = true;
  VENDOR_UNSPECIFIED = 0;
  VENDOR_ANTHROPIC = 1;
  VENDOR_CLAUDE = 1 [deprecated = true];
  VENDOR_OPENAI = 2;
  VENDOR_CODEX = 2 [deprecated = true];
}
```

Generated code carries both constants at the same value. JSON accepts either name and emits the first declared, so `VENDOR_ANTHROPIC` becomes canonical on output while `"VENDOR_CLAUDE"` still parses on input. `allow_alias` is banned by the STANDARD lint set, hence the targeted ignore — verified that the rename fails `buf breaking` without the alias and passes with it.

**The alias does not remove the migrations**, it sequences them. Three things still hold the old names and are the risk the spec names: subscription rows (`vendor TEXT` plus its CHECK constraint), the provisioned OpenZiti services and Dial policies, and the `llm-native-<vendor>` role attributes stamped on **live** workload identities. A workload holding `llm-native-claude` after its service is renamed dials something that no longer exists and silently stops reaching its vendor.

## Placeholders are typed

A placeholder is the dummy credential an agent CLI needs to start, which the proxy discards and replaces. Codex reads its subscription credential from `~/.codex/auth.json` rather than an environment variable, so the mechanism gains a second kind — and the kinds have different writers:

| Kind | Written by | Why it survives into a sandbox shell |
|---|---|---|
| `ENV` | Agents Orchestrator, onto the container spec | The runner's `Exec` carries no environment, so the session inherits the container spec's |
| `FILE` | `agynd`, at container start | The filesystem outlives the writer, so a session exec'd hours later finds it |

`SubscriptionAttachment` therefore carries `placeholder_kind` plus the variable name (ENV) or the path and contents (FILE), so neither writer holds a vendor table of its own. `placeholder_env` keeps its field number and its meaning for the ENV kind.

## Sequencing

This lands first — every service regenerates from the published module. Implementation follows in `llm`, `agents-orchestrator`, `agynd-cli`, `llm-proxy`, `bundle-vm`, `agyn-cli`, `console-app`, and `e2e`, along with the three migrations above.
