### PR TITLE
Give the platform admin identity a type of its own

### DIFF
--- a/proto/agynio/api/identity/v1/identity.proto
+++ b/proto/agynio/api/identity/v1/identity.proto
@@ -35,6 +35,9 @@ enum IdentityType {
   IDENTITY_TYPE_APP = 5;
   IDENTITY_TYPE_AGENT_INSTANCE = 6;
   IDENTITY_TYPE_SANDBOX = 7;
+  // The platform admin identity, which provisions what a release ships. Not a
+  // user: it has no account in Users and must never acquire one.
+  IDENTITY_TYPE_PLATFORM = 8;
   reserved 3;
   reserved "IDENTITY_TYPE_CHANNEL";
 }


### PR DESCRIPTION
The bootstrap token the Gateway accepts resolves to an identity typed `user`, and that identity has no record in Users. It is therefore a member the Console cannot name, and it sits one plausible change away from being provisioned as a real account — which would spend the one-shot first-admin claim at install time, before any operator has signed in.

`IDENTITY_TYPE_PLATFORM` names it for what it is: the identity that provisions what a release ships. It has no user account and never acquires one, so no path through user provisioning applies to it.

Additive, so nothing that switches on the existing values changes behaviour; services that require a user or a workload reject it through the default branches they already have. `buf lint` and `buf breaking` are clean against `main`.

First change of [one-step-install](https://github.com/agynio/architecture/blob/main/changes/2026-08-08-one-step-install.md). The `identity` and `gateway` changes that consume it are blocked on this publishing to the BSR.