### PR TITLE
Deprecate the internal platform registration methods

### DIFF
--- a/proto/agynio/api/images/v1/images.proto
+++ b/proto/agynio/api/images/v1/images.proto
@@ -26,8 +26,13 @@ service ImagesService {
   rpc ResolveVersion(ResolveVersionRequest) returns (ResolveVersionResponse);
   // Resolve an image to an upstream repository and credential, without a tag.
   rpc ResolveImage(ResolveImageRequest) returns (ResolveImageResponse);
-  // Create if absent; return the existing record otherwise. Never updates.
-  rpc RegisterPlatformImage(RegisterPlatformImageRequest) returns (RegisterPlatformImageResponse);
+  // Superseded by provisioning: the images a release ships are declared by it
+  // and created through CreateImage as a cluster admin, so no second creation
+  // path exists for install. Retained so existing callers keep compiling while
+  // they migrate; the service does not implement it.
+  rpc RegisterPlatformImage(RegisterPlatformImageRequest) returns (RegisterPlatformImageResponse) {
+    option deprecated = true;
+  }
 }
 
 // ===========================================================================
@@ -265,6 +270,8 @@ message ResolveImageResponse {
 }
 
 message RegisterPlatformImageRequest {
+  option deprecated = true;
+
   string organization_id = 1;
   string name = 2;
   string description = 3;
@@ -277,6 +284,8 @@ message RegisterPlatformImageRequest {
 }
 
 message RegisterPlatformImageResponse {
+  option deprecated = true;
+
   Image image = 1;
   // False when an image of that name already existed, in which case image is
   // the existing record, untouched.

--- a/proto/agynio/api/organizations/v1/organizations.proto
+++ b/proto/agynio/api/organizations/v1/organizations.proto
@@ -16,12 +16,13 @@ service OrganizationsService {
   // Resolve a slug to an organization. Internal: the Image Proxy resolves the
   // slug in a reference path before asking the catalog for the image.
   rpc GetOrganizationBySlug(GetOrganizationBySlugRequest) returns (GetOrganizationBySlugResponse);
-  // Create the organization platform-shipped resources live in, if no
-  // organization holds that slug, and return the existing one otherwise. It has
-  // no members: cluster admins already hold owner-level access to every
-  // organization, so it is administrable without anyone being added to it.
-  // Internal-only, authenticated as a service identity rather than a user.
-  rpc RegisterPlatformOrganization(RegisterPlatformOrganizationRequest) returns (RegisterPlatformOrganizationResponse);
+  // Superseded by provisioning: the system organization is declared by the
+  // release and created through CreateOrganization as a cluster admin, so no
+  // second creation path exists for install. Retained so existing callers keep
+  // compiling while they migrate; the service does not implement it.
+  rpc RegisterPlatformOrganization(RegisterPlatformOrganizationRequest) returns (RegisterPlatformOrganizationResponse) {
+    option deprecated = true;
+  }
   rpc UpdateOrganization(UpdateOrganizationRequest) returns (UpdateOrganizationResponse);
   rpc DeleteOrganization(DeleteOrganizationRequest) returns (DeleteOrganizationResponse);
   rpc ListOrganizations(ListOrganizationsRequest) returns (ListOrganizationsResponse);
@@ -86,11 +87,15 @@ message CreateOrganizationResponse {
 }
 
 message RegisterPlatformOrganizationRequest {
+  option deprecated = true;
+
   string slug = 1;
   string name = 2;
 }
 
 message RegisterPlatformOrganizationResponse {
+  option deprecated = true;
+
   Organization organization = 1;
   // False when an organization already held that slug, in which case
   // organization is the existing record, untouched.


### PR DESCRIPTION
`RegisterPlatformOrganization` and `RegisterPlatformImage` exist because provisioning had no identity: they are called with none, fenced by Istio principal, and create-if-absent so a re-run cannot overwrite an edit. Both are a second creation path on a service that already has one, existing only for install.

Provisioning now calls the ordinary Gateway API as a cluster admin, so neither has a caller left. A provisioned resource is created the same way an operator's is, which is what lets a release correct a resource it shipped earlier — create-if-absent could not.

**Deprecated, not deleted**, matching how the flavor methods on `RunnersService` were retired: existing callers keep compiling while they migrate, and the services stop implementing them. `buf lint` and `buf breaking` are both clean against `main`.

The service-side removals (implementations, Istio policies, the provisioner Job) land in `agynio/organizations` and `agynio/images`. Those depend on the [provisioning controller](https://github.com/agynio/provisioning) reconciling organizations and images first — otherwise a release ships with nothing creating the system organization.

Part of [one-step-install](https://github.com/agynio/architecture/blob/main/changes/2026-08-08-one-step-install.md); follows #180.