### PR TITLE
Deprecate agents.init_image

### DIFF
--- a/proto/agynio/api/agents/v1/agents.proto
+++ b/proto/agynio/api/agents/v1/agents.proto
@@ -248,7 +248,10 @@ message Agent {
   // definition instead of each carrying its own copy.
   string image = 7 [deprecated = true];
   ComputeResources resources = 8 [deprecated = true];
-  string init_image = 9;
+  // Superseded by the environment's agent_runtime_image_id. Nothing reads this:
+  // the orchestrator refuses a workload whose environment names no runtime
+  // rather than substituting an agent-supplied image.
+  string init_image = 9 [deprecated = true];
   string organization_id = 10;
   string nickname = 11;
   optional string idle_timeout = 12; // Go duration string (e.g., "30s", "5m", "1h").
@@ -281,7 +284,7 @@ message CreateAgentRequest {
   string image = 6 [deprecated = true];
   ComputeResources resources = 7 [deprecated = true];
   string organization_id = 8;
-  string init_image = 9;
+  string init_image = 9 [deprecated = true];
   string nickname = 10;
   optional string idle_timeout = 11; // Go duration string (e.g., "30s", "5m", "1h").
   // Capabilities supported by this agent. Free-form strings (e.g., "privileged", "dind").
@@ -329,7 +332,7 @@ message UpdateAgentRequest {
   optional string configuration = 6;
   optional string image = 7 [deprecated = true];
   optional ComputeResources resources = 8 [deprecated = true];
-  optional string init_image = 9;
+  optional string init_image = 9 [deprecated = true];
   optional string nickname = 10;
   optional string idle_timeout = 11; // Go duration string (e.g., "30s", "5m", "1h").
   // Capabilities replace the existing list; an empty list clears all capabilities.


### PR DESCRIPTION
Superseded by the environment's `agent_runtime_image_id`.

Nothing reads it any more. The orchestrator's legacy init container is gone: a workload whose environment names no runtime image is refused at assembly rather than falling back to the agent's own `init_image`. Environment-less agents are not supported, so there is no configuration left where this field decides anything.

Marked deprecated on all three messages that carry it rather than removed, so existing callers keep compiling.