### PR TITLE
Give devices the connectivity view tunnels already have

### DIFF
--- a/proto/agynio/api/users/v1/users.proto
+++ b/proto/agynio/api/users/v1/users.proto
@@ -52,6 +52,12 @@ enum DeviceStatus {
   DEVICE_STATUS_ENROLLED = 2;
 }
 
+enum DeviceConnectivity {
+  DEVICE_CONNECTIVITY_UNSPECIFIED = 0;
+  DEVICE_CONNECTIVITY_ONLINE = 1;
+  DEVICE_CONNECTIVITY_OFFLINE = 2;
+}
+
 // ===========================================================================
 // Common
 // ===========================================================================
@@ -83,7 +89,12 @@ message Device {
   string user_identity_id = 2;
   string name = 3;
   string openziti_identity_id = 4;
+  // Whether the enrollment token has been redeemed.
   DeviceStatus status = 5;
+  // Whether the enrolled device currently holds an edge router connection.
+  DeviceConnectivity connectivity = 6;
+  optional google.protobuf.Timestamp enrolled_at = 7;
+  optional google.protobuf.Timestamp last_seen_at = 8;
 }
 
 // ===========================================================================


### PR DESCRIPTION
`DeviceStatus` only models enrollment (`PENDING`/`ENROLLED`), so the console can show a device as Enrolled but has no way to say whether it is actually reachable. Devices sit permanently at "Enrolled" once the token is redeemed, even when the machine is off.

`TunnelCredential` already splits this into two axes — `enrollment_state` and `connectivity`, plus `enrolled_at`/`last_seen_at`. This mirrors that shape for `Device`:

- new `DeviceConnectivity` enum (`UNSPECIFIED`/`ONLINE`/`OFFLINE`)
- `Device.connectivity`, `Device.enrolled_at`, `Device.last_seen_at`

`DeviceStatus` keeps its current meaning as the enrollment axis, so nothing changes for existing readers.

Deliberately **not** adding `provisioning_state`: unlike tunnels, devices have no reconcile loop — the OpenZiti identity is created synchronously in `CreateDevice` and the row is only written on success, so the field would always read `active` and carry no information.

Additive only — `buf lint` and `buf breaking --against main` both pass.

Follow-up once this publishes to the BSR: `users` gains the columns and populates `connectivity`/`last_seen_at` from the `GetIdentityLiveness` poll it now runs, and `console-app` renders the second axis.