### PR TITLE
Add ReportWorkloadState to RunnersService and RunnersGateway

### DIFF
--- a/proto/agynio/api/gateway/v1/runners.proto
+++ b/proto/agynio/api/gateway/v1/runners.proto
@@ -18,6 +18,7 @@ service RunnersGateway {
   // Service-token authenticated, like EnrollRunner: the runner reports the
   // catalog it declares in its own configuration.
   rpc ReportRunnerCatalog(agynio.api.runners.v1.ReportRunnerCatalogRequest) returns (agynio.api.runners.v1.ReportRunnerCatalogResponse);
+  rpc ReportWorkloadState(agynio.api.runners.v1.ReportWorkloadStateRequest) returns (agynio.api.runners.v1.ReportWorkloadStateResponse);
 
   // --- Flavors ---
   rpc CreateFlavor(agynio.api.runners.v1.CreateFlavorRequest) returns (agynio.api.runners.v1.CreateFlavorResponse);

--- a/proto/agynio/api/runners/v1/runners.proto
+++ b/proto/agynio/api/runners/v1/runners.proto
@@ -47,6 +47,7 @@ service RunnersService {
   rpc CreateWorkload(CreateWorkloadRequest) returns (CreateWorkloadResponse);
   rpc UpdateWorkload(UpdateWorkloadRequest) returns (UpdateWorkloadResponse);
   rpc UpdateWorkloadStatus(UpdateWorkloadStatusRequest) returns (UpdateWorkloadStatusResponse);
+  rpc ReportWorkloadState(ReportWorkloadStateRequest) returns (ReportWorkloadStateResponse);
   rpc TouchWorkload(TouchWorkloadRequest) returns (TouchWorkloadResponse);
   rpc DeleteWorkload(DeleteWorkloadRequest) returns (DeleteWorkloadResponse);
   rpc GetWorkload(GetWorkloadRequest) returns (GetWorkloadResponse);
@@ -456,6 +457,19 @@ message UpdateWorkloadRequest {
 
 message UpdateWorkloadResponse {
   Workload workload = 1;
+}
+
+message ReportWorkloadStateRequest {
+  string runner_id = 1;
+  string service_token = 2;
+  string workload_id = 3;
+  WorkloadStatus status = 4;
+  repeated Container containers = 5;
+  google.protobuf.Timestamp observed_at = 6;
+}
+
+message ReportWorkloadStateResponse {
+  bool applied = 1;
 }
 
 // Updates status and containers only. Use UpdateWorkload to set failure


### PR DESCRIPTION
Adds `ReportWorkloadState` to `RunnersService` and `RunnersGateway`, with `ReportWorkloadStateRequest` / `ReportWorkloadStateResponse`.

Additive: `buf lint` clean, `buf breaking` against `main` reports nothing.

Behaviour is specified in `architecture` — [Runners — Runner-Reported Workload State](https://github.com/agynio/architecture/blob/runner-reported-workload-state/architecture/runners.md#runner-reported-workload-state).