### PR TITLE
Add DeleteChat to ChatService and ChatGateway

### DIFF
--- a/proto/agynio/api/chat/v1/chat.proto
+++ b/proto/agynio/api/chat/v1/chat.proto
@@ -27,6 +27,8 @@ service ChatService {
   // Delegates to Threads.UpdateThread using the authenticated identity_id.
   rpc UpdateChat(UpdateChatRequest) returns (UpdateChatResponse);
 
+  rpc DeleteChat(DeleteChatRequest) returns (DeleteChatResponse);
+
   // List messages in a chat with pagination.
   // Returns an unread_count derived from Threads.GetUnackedMessageCounts.
   // Read-only — does not change acknowledgment state.
@@ -148,6 +150,16 @@ message UpdateChatRequest {
 message UpdateChatResponse {
   Chat chat = 1;
 }
+
+// ===========================================================================
+// DeleteChat
+// ===========================================================================
+
+message DeleteChatRequest {
+  string chat_id = 1; // UUID
+}
+
+message DeleteChatResponse {}
 
 // ===========================================================================
 // GetMessages

--- a/proto/agynio/api/gateway/v1/chat.proto
+++ b/proto/agynio/api/gateway/v1/chat.proto
@@ -10,6 +10,7 @@ service ChatGateway {
   rpc CreateChat(agynio.api.chat.v1.CreateChatRequest) returns (agynio.api.chat.v1.CreateChatResponse);
   rpc GetChats(agynio.api.chat.v1.GetChatsRequest) returns (agynio.api.chat.v1.GetChatsResponse);
   rpc UpdateChat(agynio.api.chat.v1.UpdateChatRequest) returns (agynio.api.chat.v1.UpdateChatResponse);
+  rpc DeleteChat(agynio.api.chat.v1.DeleteChatRequest) returns (agynio.api.chat.v1.DeleteChatResponse);
   rpc GetMessages(agynio.api.chat.v1.GetMessagesRequest) returns (agynio.api.chat.v1.GetMessagesResponse);
   rpc SendMessage(agynio.api.chat.v1.SendMessageRequest) returns (agynio.api.chat.v1.SendMessageResponse);
   rpc MarkAsRead(agynio.api.chat.v1.MarkAsReadRequest) returns (agynio.api.chat.v1.MarkAsReadResponse);


### PR DESCRIPTION
Adds the `DeleteChat` RPC to `ChatService` and `ChatGateway`, with `DeleteChatRequest` and `DeleteChatResponse`.