### PR TITLE
Add private resource destinations to egress rules

### DIFF
--- a/proto/agynio/api/egress/v1/egress.proto
+++ b/proto/agynio/api/egress/v1/egress.proto
@@ -24,6 +24,9 @@ service EgressRulesService {
   rpc ListEgressRulesByAgent(ListEgressRulesByAgentRequest) returns (ListEgressRulesByAgentResponse);
   rpc ListEgressRulesByEnvironment(ListEgressRulesByEnvironmentRequest) returns (ListEgressRulesByEnvironmentResponse);
   rpc CountRulesReferencingSecret(CountRulesReferencingSecretRequest) returns (CountRulesReferencingSecretResponse);
+  rpc CountRulesReferencingPrivateResource(CountRulesReferencingPrivateResourceRequest) returns (CountRulesReferencingPrivateResourceResponse);
+  rpc ListMediatedPrivateResources(ListMediatedPrivateResourcesRequest) returns (ListMediatedPrivateResourcesResponse);
+  rpc ListAttachedRuleDomains(ListAttachedRuleDomainsRequest) returns (ListAttachedRuleDomainsResponse);
 }
 
 // Metadata shared by egress resources.
@@ -57,6 +60,15 @@ message EgressRuleMatcher {
   repeated string methods = 3;
   // Glob over the request path. Empty means any path.
   string path_pattern = 4;
+  string private_resource_id = 5;
+}
+
+message EgressRuleUpstreamTls {
+  string server_name = 1;
+  oneof trust {
+    string ca_bundle_secret_id = 2;
+    bool insecure_skip_verify = 3;
+  }
 }
 
 // Header credential injected by the egress gateway.
@@ -83,6 +95,7 @@ message EgressRule {
   string description = 4;
   EgressRuleMatcher matcher = 5;
   EgressRuleEffect effect = 6;
+  optional EgressRuleUpstreamTls upstream_tls = 7;
 }
 
 // Attachment binding an egress rule to an agent or environment.
@@ -102,6 +115,7 @@ message CreateEgressRuleRequest {
   string description = 3;
   EgressRuleMatcher matcher = 4;
   EgressRuleEffect effect = 5;
+  optional EgressRuleUpstreamTls upstream_tls = 6;
 }
 
 message CreateEgressRuleResponse {
@@ -116,10 +130,18 @@ message GetEgressRuleResponse {
   EgressRule egress_rule = 1;
 }
 
+enum EgressRuleTargetKind {
+  EGRESS_RULE_TARGET_KIND_UNSPECIFIED = 0;
+  EGRESS_RULE_TARGET_KIND_PUBLIC = 1;
+  EGRESS_RULE_TARGET_KIND_PRIVATE = 2;
+}
+
 message ListEgressRulesRequest {
   string organization_id = 1;
   int32 page_size = 2;
   string page_token = 3;
+  optional string private_resource_id = 4;
+  optional EgressRuleTargetKind target_kind = 5;
 }
 
 message ListEgressRulesResponse {
@@ -133,6 +155,7 @@ message UpdateEgressRuleRequest {
   optional string description = 3;
   optional EgressRuleMatcher matcher = 4;
   optional EgressRuleEffect effect = 5;
+  optional EgressRuleUpstreamTls upstream_tls = 6;
 }
 
 message UpdateEgressRuleResponse {
@@ -179,12 +202,24 @@ message ListEgressRuleAttachmentsResponse {
   string next_page_token = 2;
 }
 
+enum EgressPrivateResourceProtocol {
+  EGRESS_PRIVATE_RESOURCE_PROTOCOL_UNSPECIFIED = 0;
+  EGRESS_PRIVATE_RESOURCE_PROTOCOL_HTTP = 1;
+  EGRESS_PRIVATE_RESOURCE_PROTOCOL_HTTPS = 2;
+}
+
+message PrivateResourceInfo {
+  string intercept_host = 1;
+  EgressPrivateResourceProtocol protocol = 2;
+}
+
 message ListEgressRulesByAgentRequest {
   string agent_id = 1;
 }
 
 message ListEgressRulesByAgentResponse {
   repeated EgressRule egress_rules = 1;
+  map<string, PrivateResourceInfo> private_resources = 2;
 }
 
 message ListEgressRulesByEnvironmentRequest {
@@ -193,6 +228,7 @@ message ListEgressRulesByEnvironmentRequest {
 
 message ListEgressRulesByEnvironmentResponse {
   repeated EgressRule egress_rules = 1;
+  map<string, PrivateResourceInfo> private_resources = 2;
 }
 
 message CountRulesReferencingSecretRequest {
@@ -202,4 +238,38 @@ message CountRulesReferencingSecretRequest {
 message CountRulesReferencingSecretResponse {
   int32 count = 1;
   repeated string egress_rule_ids = 2;
+}
+
+message CountRulesReferencingPrivateResourceRequest {
+  string private_resource_id = 1;
+}
+
+message CountRulesReferencingPrivateResourceResponse {
+  int32 count = 1;
+  repeated string egress_rule_ids = 2;
+}
+
+message ListMediatedPrivateResourcesRequest {
+  string organization_id = 1;
+}
+
+message ListMediatedPrivateResourcesResponse {
+  repeated string private_resource_ids = 1;
+}
+
+message AttachedRuleDomain {
+  string egress_rule_id = 1;
+  string domain_pattern = 2;
+  repeated int32 ports = 3;
+}
+
+message ListAttachedRuleDomainsRequest {
+  oneof principal {
+    string agent_id = 1;
+    string environment_id = 2;
+  }
+}
+
+message ListAttachedRuleDomainsResponse {
+  repeated AttachedRuleDomain domains = 1;
 }

--- a/proto/agynio/api/gateway/v1/networks.proto
+++ b/proto/agynio/api/gateway/v1/networks.proto
@@ -32,3 +32,7 @@ service NetworksGateway {
   rpc DeletePrivateResourceAccess(agynio.api.networks.v1.DeletePrivateResourceAccessRequest) returns (agynio.api.networks.v1.DeletePrivateResourceAccessResponse);
   rpc ListPrivateResourceAccess(agynio.api.networks.v1.ListPrivateResourceAccessRequest) returns (agynio.api.networks.v1.ListPrivateResourceAccessResponse);
 }
+
+// SetPrivateResourceMediation and ListPrivateResourcesReachableBy are
+// deliberately absent: they are internal calls from the EgressRules service,
+// and the Gateway is the external surface.

--- a/proto/agynio/api/networks/v1/networks.proto
+++ b/proto/agynio/api/networks/v1/networks.proto
@@ -32,6 +32,10 @@ service NetworksService {
   rpc CreatePrivateResourceAccess(CreatePrivateResourceAccessRequest) returns (CreatePrivateResourceAccessResponse);
   rpc DeletePrivateResourceAccess(DeletePrivateResourceAccessRequest) returns (DeletePrivateResourceAccessResponse);
   rpc ListPrivateResourceAccess(ListPrivateResourceAccessRequest) returns (ListPrivateResourceAccessResponse);
+
+  // --- Internal ---
+  rpc SetPrivateResourceMediation(SetPrivateResourceMediationRequest) returns (SetPrivateResourceMediationResponse);
+  rpc ListPrivateResourcesReachableBy(ListPrivateResourcesReachableByRequest) returns (ListPrivateResourcesReachableByResponse);
 }
 
 // Metadata shared by network resources.
@@ -69,6 +73,12 @@ enum PrivateResourceProtocol {
   PRIVATE_RESOURCE_PROTOCOL_TCP = 1;
   PRIVATE_RESOURCE_PROTOCOL_HTTP = 2;
   PRIVATE_RESOURCE_PROTOCOL_HTTPS = 3;
+}
+
+enum PrivateResourceMediation {
+  PRIVATE_RESOURCE_MEDIATION_UNSPECIFIED = 0;
+  PRIVATE_RESOURCE_MEDIATION_TUNNEL = 1;
+  PRIVATE_RESOURCE_MEDIATION_EGRESS_GATEWAY = 2;
 }
 
 // Principal types eligible for private resource access.
@@ -118,6 +128,7 @@ message PrivateResource {
   // Numeric intercept ports. Each value must be in the range 1..65535.
   repeated int32 intercept_ports = 9;
   ProvisioningState provisioning_state = 10;
+  PrivateResourceMediation mediation = 11;
 }
 
 // Immutable grant authorizing a principal to dial a private resource.
@@ -303,4 +314,36 @@ message ListPrivateResourceAccessRequest {
 message ListPrivateResourceAccessResponse {
   repeated PrivateResourceAccess private_resource_access = 1;
   string next_page_token = 2;
+}
+
+message SetPrivateResourceMediationRequest {
+  string id = 1;
+  PrivateResourceMediation mediation = 2;
+}
+
+message SetPrivateResourceMediationResponse {
+  PrivateResource private_resource = 1;
+}
+
+message ReachablePrivateResourceGrant {
+  PrivateResourceAccessPrincipalType principal_type = 1;
+  string principal_id = 2;
+}
+
+message ReachablePrivateResource {
+  string id = 1;
+  string intercept_host = 2;
+  repeated int32 intercept_ports = 3;
+  repeated ReachablePrivateResourceGrant grants = 4;
+}
+
+message ListPrivateResourcesReachableByRequest {
+  oneof principal {
+    string agent_id = 1;
+    string environment_id = 2;
+  }
+}
+
+message ListPrivateResourcesReachableByResponse {
+  repeated ReachablePrivateResource private_resources = 1;
 }

--- a/proto/agynio/api/ziti_management/v1/ziti_management.proto
+++ b/proto/agynio/api/ziti_management/v1/ziti_management.proto
@@ -594,10 +594,15 @@ message UpdateServiceRequest {
   // Deprecated: use tags_update to distinguish omitted from empty.
   map<string, string> tags = 4 [deprecated = true];
   optional TagsUpdate tags_update = 5;
+  optional RoleAttributesUpdate role_attributes_update = 6;
 }
 
 message TagsUpdate {
   map<string, string> tags = 1;
+}
+
+message RoleAttributesUpdate {
+  repeated string role_attributes = 1;
 }
 
 message UpdateServiceResponse {


### PR DESCRIPTION
- \`EgressRuleMatcher.private_resource_id\`, mutually exclusive with \`domain_pattern\`; \`ports\` stays public-only
- \`EgressRuleUpstreamTls\` (\`server_name\`, \`ca_bundle_secret_id\` xor \`insecure_skip_verify\`) on \`EgressRule\` and the create/update requests
- \`ListEgressRules\` filters: \`private_resource_id\`, \`target_kind\`
- \`ListEgressRulesByAgent\`/\`ByEnvironment\` responses carry a \`PrivateResourceInfo\` map (\`intercept_host\`, \`protocol\`) keyed by resource id
- EgressRules internal RPCs: \`CountRulesReferencingPrivateResource\`, \`ListMediatedPrivateResources\`, \`ListAttachedRuleDomains\`
- \`PrivateResource.mediation\` (\`PrivateResourceMediation\` enum)
- Networks internal RPCs: \`SetPrivateResourceMediation\`, \`ListPrivateResourcesReachableBy\` (with per-resource \`grants\`); absent from \`NetworksGateway\`
- \`UpdateServiceRequest.role_attributes_update\` on Ziti Management